### PR TITLE
Make it easier to add more hooks and add Prepare-message hook

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -50,9 +50,10 @@ class Config
     {
         $this->path                = $path;
         $this->fileExists          = $fileExists;
-        $this->hooks['commit-msg'] = new Config\Hook();
-        $this->hooks['pre-commit'] = new Config\Hook();
-        $this->hooks['pre-push']   = new Config\Hook();
+
+        foreach (Hooks::getValidHooks() as $hook => $value) {
+            $this->hooks[$hook] = new Config\Hook();
+        }
     }
 
     /**
@@ -97,10 +98,12 @@ class Config
      */
     public function getJsonData() : array
     {
-        return [
-            'commit-msg' => $this->hooks['commit-msg']->getJsonData(),
-            'pre-commit' => $this->hooks['pre-commit']->getJsonData(),
-            'pre-push'   => $this->hooks['pre-push']->getJsonData()
-        ];
+        $return = [];
+
+        foreach (Hooks::getValidHooks() as $hook => $value) {
+            $return[$hook] = $this->hooks[$hook]->getJsonData();
+        }
+
+        return $return;
     }
 }

--- a/src/Console/Application/Hook.php
+++ b/src/Console/Application/Hook.php
@@ -11,6 +11,7 @@ namespace CaptainHook\App\Console\Application;
 
 use CaptainHook\App\Hook\Util;
 use CaptainHook\App\Console\Command;
+use CaptainHook\App\Hooks;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -44,9 +45,9 @@ class Hook extends ConfigHandler
      * @var array
      */
     protected $hookCommandMap = [
-        'pre-commit' => 'PreCommit',
-        'commit-msg' => 'CommitMsg',
-        'pre-push'   => 'PrePush'
+        Hooks::PRE_COMMIT => 'PreCommit',
+        Hooks::COMMIT_MSG => 'CommitMsg',
+        Hooks::PRE_PUSH   => 'PrePush'
     ];
 
     /**

--- a/src/Console/Command/Hook/CommitMsg.php
+++ b/src/Console/Command/Hook/CommitMsg.php
@@ -11,6 +11,7 @@ namespace CaptainHook\App\Console\Command\Hook;
 
 use CaptainHook\App\Config;
 use CaptainHook\App\Console\Command\Hook;
+use CaptainHook\App\Hooks;
 use SebastianFeldmann\Git;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -31,7 +32,7 @@ class CommitMsg extends Hook
      *
      * @var string
      */
-    protected $hookName = 'commit-msg';
+    protected $hookName = Hooks::COMMIT_MSG;
 
     /**
      * Configure the command.

--- a/src/Console/Command/Hook/PreCommit.php
+++ b/src/Console/Command/Hook/PreCommit.php
@@ -10,6 +10,7 @@
 namespace CaptainHook\App\Console\Command\Hook;
 
 use CaptainHook\App\Console\Command\Hook;
+use CaptainHook\App\Hooks;
 
 /**
  * Class PreCommit
@@ -26,5 +27,5 @@ class PreCommit extends Hook
      *
      * @var string
      */
-    protected $hookName = 'pre-commit';
+    protected $hookName = Hooks::PRE_COMMIT;
 }

--- a/src/Console/Command/Hook/PrePush.php
+++ b/src/Console/Command/Hook/PrePush.php
@@ -10,6 +10,7 @@
 namespace CaptainHook\App\Console\Command\Hook;
 
 use CaptainHook\App\Console\Command\Hook;
+use CaptainHook\App\Hooks;
 use Symfony\Component\Console\Input\InputArgument;
 
 /**
@@ -27,7 +28,7 @@ class PrePush extends Hook
      *
      * @var string
      */
-    protected $hookName = 'pre-push';
+    protected $hookName = Hooks::PRE_PUSH;
 
     /**
      * Configure the command.

--- a/src/Hook/Util.php
+++ b/src/Hook/Util.php
@@ -9,6 +9,8 @@
  */
 namespace CaptainHook\App\Hook;
 
+use CaptainHook\App\Hooks;
+
 /**
  * Class Util
  *
@@ -20,13 +22,6 @@ namespace CaptainHook\App\Hook;
 abstract class Util
 {
     /**
-     * All valid hooks
-     *
-     * @var array
-     */
-    private static $validHooks = ['commit-msg' => 1, 'pre-commit' => 1, 'pre-push' => 1];
-
-    /**
      * Checks if a hook name is valid.
      *
      * @param  string $hook
@@ -34,7 +29,7 @@ abstract class Util
      */
     public static function isValid(string $hook) : bool
     {
-        return isset(self::$validHooks[$hook]);
+        return isset(Hooks::getValidHooks()[$hook]);
     }
 
     /**
@@ -44,7 +39,7 @@ abstract class Util
      */
     public static function getValidHooks() : array
     {
-        return self::$validHooks;
+        return Hooks::getValidHooks();
     }
 
     /**
@@ -54,7 +49,7 @@ abstract class Util
      */
     public static function getHooks() : array
     {
-        return array_keys(self::$validHooks);
+        return array_keys(Hooks::getValidHooks());
     }
 
     /**

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright Andrea Heigl <andreas@heigl.org>
+ *
+ * Licenses under the MIT-license. For details see the included file LICENSE.md
+ */
+
+namespace CaptainHook\App;
+
+
+final class Hooks
+{
+    const PRE_COMMIT = 'pre-commit';
+
+    const PRE_PUSH = 'pre-push';
+
+    const COMMIT_MSG = 'commit-msg';
+
+    public static function getValidHooks() : array
+    {
+        return [
+            self::COMMIT_MSG => 1,
+            self::PRE_PUSH   => 1,
+            self::PRE_COMMIT => 1,
+        ];
+    }
+}

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -19,12 +19,15 @@ final class Hooks
 
     const COMMIT_MSG = 'commit-msg';
 
+    const PREPARE_COMMIT_MSG = 'prepare-commit-msg';
+
     public static function getValidHooks() : array
     {
         return [
             self::COMMIT_MSG => 1,
             self::PRE_PUSH   => 1,
             self::PRE_COMMIT => 1,
+            self::PREPARE_COMMIT_MSG => 1,
         ];
     }
 }

--- a/src/Runner/Configurator/Setup/Express.php
+++ b/src/Runner/Configurator/Setup/Express.php
@@ -11,6 +11,7 @@ namespace CaptainHook\App\Runner\Configurator\Setup;
 
 use CaptainHook\App\Config;
 use CaptainHook\App\Console\IOUtil;
+use CaptainHook\App\Hooks;
 use CaptainHook\App\Runner\Configurator\Setup;
 
 /**
@@ -31,8 +32,8 @@ class Express extends Guided implements Setup
      */
     public function configureHooks(Config $config)
     {
-        $msgHook = $config->getHookConfig('commit-msg');
-        $preHook = $config->getHookConfig('pre-commit');
+        $msgHook = $config->getHookConfig(Hooks::COMMIT_MSG);
+        $preHook = $config->getHookConfig(Hooks::PRE_COMMIT);
         $msgHook->setEnabled(true);
         $preHook->setEnabled(true);
 

--- a/tests/CaptainHook/Runner/Configurator/Setup/AdvancedTest.php
+++ b/tests/CaptainHook/Runner/Configurator/Setup/AdvancedTest.php
@@ -20,7 +20,7 @@ class AdvancedTest extends BaseTestRunner
     {
         $io     = $this->getIOMock();
         $config = $this->getConfigMock();
-        $config->expects($this->exactly(3))->method('getHookConfig')->willReturn($this->getHookConfigMock());
+        $config->expects($this->exactly(4))->method('getHookConfig')->willReturn($this->getHookConfigMock());
         $io->method('ask')->will($this->onConsecutiveCalls('y', 'y', 'echo \'foo\'', 'n'));
 
         $setup  = new Advanced($io);


### PR DESCRIPTION
This PR makes it easier to add new hooks to captainhook by extracting all the informations into a snigle class. Therefore additions of new hooks only need to be done in that one class and not in multiple files (perhaps apart from tests).

Additionally it adds a hook for preparing the commit-message so that the commit-message the user gets displayed can actually be altered by hooks now.