### PR TITLE
Add possibility to use ActionFactory

### DIFF
--- a/src/Hook/ActionFactory.php
+++ b/src/Hook/ActionFactory.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of CaptainHook.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian.feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace CaptainHook\App\Hook;
+
+use CaptainHook\App\Config;
+
+/**
+ * Interface ActionFactory
+ *
+ * @package CaptainHook
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/captaionhookphp/captainhook
+ * @since   Interface available since Release 3.1.1
+ */
+interface ActionFactory
+{
+    /**
+     * Retrieve the action.
+     *
+     * @param  \CaptainHook\App\Config\Options  $option
+     *
+     * @return Action
+     * @throws \Exception
+     */
+    public function getAction(Config\Options $option) : Action;
+}


### PR DESCRIPTION
This adds the possibiliity to use an ActionFactory in the configuration instead of an Action directly.

The Options from the configuration are passed to the ActionFactory::getAction-Method to enable creation of customized classes. these classes need to implement the Action-Interface.

That way the creation of the custom-class is separated from the actual execution of the Action.