### PR TITLE
Update logic and "parse errors" on extend.html

### DIFF
--- a/extend.html
+++ b/extend.html
@@ -221,7 +221,7 @@ class NotOnMonday implements Condition
      */
     public function isTrue(IO $io, Repository $repository) : bool
     {
-        return date('D') != 'MON';
+        return date('D') !== 'Mon';
     }
 }</code></pre>
 
@@ -283,7 +283,7 @@ class NotOnAnyWeekday implements Condition
      */
     public function isTrue(IO $io, Repository $repository) : bool
     {
-        return !in_array(date('D'), $this->weekdays;
+        return !in_array(date('D'), $this->weekdays);
     }
 }</code></pre>
 
@@ -301,7 +301,7 @@ class NotOnAnyWeekday implements Condition
           {
             "exec:"\\MyName\\HookConditions\\NotOnMonday",
             "args": [
-              ["Mon", "SAT"]
+              ["Mon", "Sat"]
             ]
           }
         ]


### PR DESCRIPTION
I stumbled upon some minor logic and parse errors.
I don't know if they are on purpose, like:

```
in_array(date('D'), ['Mon, 'SAT'])
```

which will only hit on monday.
But anyway, I thought updating it to actually working code might be fine.
If not, I will revert them.