### PR TITLE
Fix: Docker binary path

### DIFF
--- a/captainhook-run
+++ b/captainhook-run
@@ -68,7 +68,7 @@ array_splice($_SERVER['argv'], 1, 1);
 require CAPTAINHOOK_COMPOSER_AUTOLOAD;
 
 // check captainhook.json
-foreach ([__DIR__ . '/../../captainhook.json', __DIR__ . '/../captainhook.json', __DIR__ . '/captainhook.json'] as $file) {
+foreach ([__DIR__ . '/../../../captainhook.json', __DIR__ . '/captainhook.json'] as $file) {
     if (file_exists($file)) {
         define('CAPTAINHOOK_CONFIG', $file);
         break;

--- a/src/Console/Command/Install.php
+++ b/src/Console/Command/Install.php
@@ -84,10 +84,10 @@ class Install extends Base
         $config = $this->getConfig($input->getOption('configuration'), true);
         $repo   = new Repository(dirname($input->getOption('git-directory')));
 
-        $runMode       = $input->getOption('run-mode');
-        $containerName = $input->getOption('container');
+        $runMode   = $input->getOption('run-mode');
+        $container = $input->getOption('container');
 
-        if ($runMode === Template::DOCKER && empty($containerName)) {
+        if ($runMode === Template::DOCKER && empty($container)) {
             throw new RuntimeException(
                 'Option "container" missing for run-mode docker.'
             );

--- a/src/Hook/Template/Builder.php
+++ b/src/Hook/Template/Builder.php
@@ -46,12 +46,10 @@ abstract class Builder
             // E.g.:
             //   cwd => /docker
             //   path => /docker/captainhook-run
-            //
             // The actual path needs to be /captainhook-run to work
             $cwd = getcwd();
 
             $repoPath = ltrim(realpath($repository->getRoot()), $cwd . DIRECTORY_SEPARATOR);
-            // TODO get vendor path from composer config
             $vendorPath = ltrim(realpath(getcwd() . '/vendor'), $cwd . DIRECTORY_SEPARATOR);
 
             return new Docker(

--- a/src/Hook/Template/Docker.php
+++ b/src/Hook/Template/Docker.php
@@ -39,19 +39,19 @@ class Docker implements Template
      *
      * @var string
      */
-    private $containerName;
+    private $container;
 
     /**
      * Docker constructor
      *
      * @param string $repoPath
      * @param string $vendorPath
-     * @param string $containerName
+     * @param string $container
      */
-    public function __construct(string $repoPath, string $vendorPath, string $containerName)
+    public function __construct(string $repoPath, string $vendorPath, string $container)
     {
-        $this->binaryPath    = Util::getBinaryPath($repoPath, $vendorPath, 'captainhook-run');
-        $this->containerName = $containerName;
+        $this->binaryPath = ltrim(Util::resolveBinaryPath($repoPath, $vendorPath, 'captainhook-run'), DIRECTORY_SEPARATOR);
+        $this->container  = $container;
     }
 
     /**
@@ -63,6 +63,6 @@ class Docker implements Template
     public function getCode(string $hook): string
     {
         return '#!/usr/bin/env bash' . PHP_EOL .
-            'docker exec ' . $this->containerName . ' ./' . $this->binaryPath . ' ' . $hook . ' "$@"';
+            'docker exec ' . $this->container . ' ./' . $this->binaryPath . ' ' . $hook . ' "$@"';
     }
 }

--- a/src/Storage/Util.php
+++ b/src/Storage/Util.php
@@ -77,8 +77,8 @@ class Util
      */
     public static function getTplTargetPath(string $repoDir, string $targetPath) : string
     {
-        $repo   = explode(DIRECTORY_SEPARATOR, ltrim($repoDir, DIRECTORY_SEPARATOR));
-        $target = explode(DIRECTORY_SEPARATOR, ltrim($targetPath, DIRECTORY_SEPARATOR));
+        $repo   = self::pathToArray($repoDir);
+        $target = self::pathToArray($targetPath);
 
         if (!self::isSubDirectoryOf($target, $repo)) {
             return '\'' . $targetPath;
@@ -88,22 +88,24 @@ class Util
     }
 
     /**
-     * Returns the path to the captainhook-run binary
+     * Resolves the path to the captainhook-run binary and returns it.
+     *
+     * This path is either right inside the repo itself (captainhook) or only in vendor path.
+     * Which happens if captainhook is required as dependency.
      *
      * @param  string $repoDir
      * @param  string $vendorPath
      * @param  string $binary
      * @return string
      */
-    public static function getBinaryPath(string $repoDir, string $vendorPath, string $binary): string
+    public static function resolveBinaryPath(string $repoDir, string $vendorPath, string $binary): string
     {
-        $repo   = explode(DIRECTORY_SEPARATOR, ltrim($repoDir, DIRECTORY_SEPARATOR));
-        $vendor = explode(DIRECTORY_SEPARATOR, ltrim($vendorPath, DIRECTORY_SEPARATOR));
+        $binaryPath = $repoDir . DIRECTORY_SEPARATOR . $binary;
 
-        if (!self::isSubDirectoryOf($vendor, $repo)) {
+        if (!file_exists($binary)) {
             return $vendorPath . '/bin/' . $binary;
         }
 
-        return $binary;
+        return $binaryPath;
     }
 }

--- a/src/Storage/Util.php
+++ b/src/Storage/Util.php
@@ -102,7 +102,7 @@ class Util
     {
         $binaryPath = $repoDir . DIRECTORY_SEPARATOR . $binary;
 
-        if (!file_exists($binary)) {
+        if (!file_exists($binaryPath)) {
             return $vendorPath . '/bin/' . $binary;
         }
 

--- a/tests/CaptainHook/Hook/Template/DockerTest.php
+++ b/tests/CaptainHook/Hook/Template/DockerTest.php
@@ -17,14 +17,32 @@ class DockerTest extends TestCase
     /**
      * Tests Docker::getCode
      */
-    public function testTemplate() : void
+    public function testTemplateFirstParty() : void
     {
-        $template = new Docker('/foo/bar', '/foo/bar/vendor', 'captain-container');
+        $repoPath = realpath(__DIR__ . '/../../../files/storage');
+
+        $template = new Docker($repoPath, 'does/not/matter', 'captain-container');
         $code = $template->getCode('commit-msg');
 
         $this->assertStringContainsString('#!/usr/bin/env bash', $code);
         $this->assertStringContainsString('docker exec', $code);
         $this->assertStringContainsString('captain-container', $code);
-        $this->assertStringContainsString('./captainhook-run', $code);
+        $this->assertStringContainsString($repoPath . '/captainhook-run', $code);
+    }
+
+    /**
+     * Tests Docker::getCode
+     */
+    public function testTemplateThirdParty() : void
+    {
+        $repoPath = realpath(__DIR__);
+
+        $template = new Docker($repoPath, $repoPath, 'captain-container');
+        $code = $template->getCode('commit-msg');
+
+        $this->assertStringContainsString('#!/usr/bin/env bash', $code);
+        $this->assertStringContainsString('docker exec', $code);
+        $this->assertStringContainsString('captain-container', $code);
+        $this->assertStringContainsString($repoPath . '/bin/captainhook-run', $code);
     }
 }

--- a/tests/CaptainHook/Storage/UtilTest.php
+++ b/tests/CaptainHook/Storage/UtilTest.php
@@ -75,14 +75,20 @@ class UtilTest extends TestCase
     }
 
     /**
-     * Tests Util::getBinaryPath
+     * Tests Util::resolveBinaryPath
      */
-    public function testGetBinaryPath(): void
+    public function testResolveBinaryPath(): void
     {
-        $path = Util::getBinaryPath('/foo/bar', '/foo/bar/vendor', 'captainhook-run');
-        $this->assertEquals('captainhook-run', $path);
+        $repoDir = realpath(__DIR__ . '/../../files/storage');
+        $vendorDir = realpath(__DIR__ . '/../../files/storage');
 
-        $path = Util::getBinaryPath('/foo/bar', '/fiz/baz/vendor', 'captainhook-run');
-        $this->assertEquals('/fiz/baz/vendor/bin/captainhook-run', $path);
+        $path = Util::resolveBinaryPath($repoDir, $vendorDir, 'captainhook-run');
+        $this->assertEquals($repoDir . '/captainhook-run', $path);
+
+        $repoDir = __DIR__;
+        $vendorDir = __DIR__;
+
+        $path = Util::resolveBinaryPath($repoDir, $vendorDir, 'captainhook-run');
+        $this->assertEquals(__DIR__ . '/bin/captainhook-run', $path);
     }
 }

--- a/tests/files/storage/captainhook-run
+++ b/tests/files/storage/captainhook-run
@@ -1,0 +1,2 @@
+<?php
+// nothing to see here, just a simple mock


### PR DESCRIPTION
With latest PR #32 docker support was added. Sadly I forgot to cross check the complete implementation. This PR solves a problem with the correct execution path for the binary inside the docker container.