### PR TITLE
Fix: Limit range of PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     }
   },
   "require": {
-    "php": ">=7.1.0",
+    "php": "^7.1",
     "ext-json": "*",
     "ext-spl": "*",
     "ext-simplexml": "*",


### PR DESCRIPTION
This PR

* [x] limits the range of PHP versions this package can be installed on

💁‍♂ We don't know yet whether this package will be compatible with PHP 9000.