### PR TITLE
[docs] Fix typo in footer

### DIFF
--- a/actions.html
+++ b/actions.html
@@ -127,7 +127,7 @@
       <p>
         Found a typo or a bug?
         Please open an <a href="https://github.com/captainhookphp/captainhook/issues">issue</a>
-        or pull request for the <em>gp-pages</em>
+        or pull request for the <em>gh-pages</em>
         branch of <a href="https://github.com/captainhookphp/captainhook/tree/gh-pages">CaptainHook</a>
       </p>
       <p>

--- a/composer.html
+++ b/composer.html
@@ -85,7 +85,7 @@
         <p>
           Found a typo or a bug?
           Please open an <a href="https://github.com/captainhookphp/captainhook/issues">issue</a>
-          or pull request for the <em>gp-pages</em>
+          or pull request for the <em>gh-pages</em>
           branch of <a href="https://github.com/captainhookphp/captainhook/tree/gh-pages">CaptainHook</a>
         </p>
         <p>

--- a/configure.html
+++ b/configure.html
@@ -207,7 +207,7 @@
         <p>
           Found a typo or a bug?
           Please open an <a href="https://github.com/captainhookphp/captainhook/issues">issue</a>
-          or pull request for the <em>gp-pages</em>
+          or pull request for the <em>gh-pages</em>
           branch of <a href="https://github.com/captainhookphp/captainhook/tree/gh-pages">CaptainHook</a>
         </p>
         <p>

--- a/extend.html
+++ b/extend.html
@@ -317,7 +317,7 @@ class NotOnAnyWeekday implements Condition
         <p>
           Found a typo or a bug?
           Please open an <a href="https://github.com/captainhookphp/captainhook/issues">issue</a>
-          or pull request for the <em>gp-pages</em>
+          or pull request for the <em>gh-pages</em>
           branch of <a href="https://github.com/captainhookphp/captainhook/tree/gh-pages">CaptainHook</a>
         </p>
         <p>

--- a/hooks.html
+++ b/hooks.html
@@ -183,7 +183,7 @@ class NoEmptyCommitMessages implements HookAction
         <p>
           Found a typo or a bug?
           Please open an <a href="https://github.com/captainhookphp/captainhook/issues">issue</a>
-          or pull request for the <em>gp-pages</em>
+          or pull request for the <em>gh-pages</em>
           branch of <a href="https://github.com/captainhookphp/captainhook/tree/gh-pages">CaptainHook</a>
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         <p>
           Found a typo or a bug?
           Please open an <a href="https://github.com/sebastianfeldmann/captainhook/issues">issue</a>
-          or pull request for the <em>gp-pages</em>
+          or pull request for the <em>gh-pages</em>
           branch of <a href="https://github.com/sebastianfeldmann/captainhook/tree/gh-pages">CaptainHook</a>
         </p>
         <p>

--- a/install.html
+++ b/install.html
@@ -114,7 +114,7 @@
         <p>
           Found a typo or a bug?
           Please open an <a href="https://github.com/captainhookphp/captainhook/issues">issue</a>
-          or pull request for the <em>gp-pages</em>
+          or pull request for the <em>gh-pages</em>
           branch of <a href="https://github.com/captainhookphp/captainhook/tree/gh-pages">CaptainHook</a>
         </p>
         <p>


### PR DESCRIPTION
In the footer there were references to `gp-pages` instead of `gh-pages`.