### PR TITLE
[docs] Fix links in footer not pointing to repo in github organization

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,9 +85,9 @@
       <div class="container">
         <p>
           Found a typo or a bug?
-          Please open an <a href="https://github.com/sebastianfeldmann/captainhook/issues">issue</a>
+          Please open an <a href="https://github.com/captainhookphp/captainhook/issues">issue</a>
           or pull request for the <em>gp-pages</em>
-          branch of <a href="https://github.com/sebastianfeldmann/captainhook/tree/gh-pages">CaptainHook</a>
+          branch of <a href="https://github.com/captainhookphp/captainhook/tree/gh-pages">CaptainHook</a>
         </p>
         <p>
           &copy; <a href="https://github.com/sebastianfeldmann">Sebastian Feldmann</a>


### PR DESCRIPTION
There seem to be some links in the footer that point to the repo location before Captain Hook moved to its own GitHub organization.