### PR TITLE
Add config inclusion feature

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -9,6 +9,8 @@
  */
 namespace CaptainHook\App;
 
+use InvalidArgumentException;
+
 /**
  * Class Config
  *
@@ -16,6 +18,7 @@ namespace CaptainHook\App;
  * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
  * @link    https://github.com/captainhookphp/captainhook
  * @since   Class available since Release 0.9.0
+ * @internal
  */
 class Config
 {
@@ -41,23 +44,23 @@ class Config
     private $hooks = [];
 
     /**
-     * Config constructor.
+     * Config constructor
      *
      * @param string $path
      * @param bool   $fileExists
      */
     public function __construct(string $path, bool $fileExists = false)
     {
-        $this->path                = $path;
-        $this->fileExists          = $fileExists;
+        $this->path       = $path;
+        $this->fileExists = $fileExists;
 
         foreach (Hooks::getValidHooks() as $hook => $value) {
-            $this->hooks[$hook] = new Config\Hook();
+            $this->hooks[$hook] = new Config\Hook($hook);
         }
     }
 
     /**
-     * Is configuration loaded from file.
+     * Is configuration loaded from file
      *
      * @return bool
      */
@@ -67,7 +70,7 @@ class Config
     }
 
     /**
-     * Path getter.
+     * Path getter
      *
      * @return string
      */
@@ -77,7 +80,7 @@ class Config
     }
 
     /**
-     * Return config for given hook.
+     * Return config for given hook
      *
      * @param  string $hook
      * @return \CaptainHook\App\Config\Hook
@@ -86,13 +89,13 @@ class Config
     public function getHookConfig(string $hook) : Config\Hook
     {
         if (!Hook\Util::isValid($hook)) {
-            throw new \InvalidArgumentException('Invalid hook name: ' . $hook);
+            throw new InvalidArgumentException('Invalid hook name: ' . $hook);
         }
         return $this->hooks[$hook];
     }
 
     /**
-     * Return config array to write to disc.
+     * Return config array to write to disc
      *
      * @return array
      */

--- a/src/Config/Action.php
+++ b/src/Config/Action.php
@@ -16,6 +16,7 @@ namespace CaptainHook\App\Config;
  * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
  * @link    https://github.com/captainhookphp/captainhook
  * @since   Class available since Release 0.9.0
+ * @internal
  */
 class Action
 {

--- a/src/Config/Condition.php
+++ b/src/Config/Condition.php
@@ -16,6 +16,7 @@ namespace CaptainHook\App\Config;
  * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
  * @link    https://github.com/captainhookphp/captainhook
  * @since   Class available since Release 4.2.0
+ * @internal
  */
 class Condition
 {

--- a/src/Config/Hook.php
+++ b/src/Config/Hook.php
@@ -16,9 +16,17 @@ namespace CaptainHook\App\Config;
  * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
  * @link    https://github.com/captainhookphp/captainhook
  * @since   Class available since Release 0.9.0
+ * @internal
  */
 class Hook
 {
+    /**
+     * Hook name e.g. pre-commit
+     *
+     * @var string
+     */
+    private $name;
+
     /**
      * Is hook enabled
      *
@@ -36,11 +44,23 @@ class Hook
     /**
      * Hook constructor
      *
-     * @param bool $enabled
+     * @param string $name
+     * @param bool   $enabled
      */
-    public function __construct(bool $enabled = false)
+    public function __construct(string $name, bool $enabled = false)
     {
+        $this->name      = $name;
         $this->isEnabled = $enabled;
+    }
+
+    /**
+     * Name getter
+     *
+     * @return string
+     */
+    public function getName() : string
+    {
+        return $this->name;
     }
 
     /**

--- a/src/Config/Options.php
+++ b/src/Config/Options.php
@@ -16,6 +16,7 @@ namespace CaptainHook\App\Config;
  * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
  * @link    https://github.com/captainhookphp/captainhook
  * @since   Class available since Release 1.0.0
+ * @internal
  */
 class Options
 {

--- a/src/Config/Util.php
+++ b/src/Config/Util.php
@@ -12,6 +12,7 @@ namespace CaptainHook\App\Config;
 use CaptainHook\App\Hook\Util as HookUtil;
 use CaptainHook\App\Config;
 use CaptainHook\App\Storage\File\Json;
+use RuntimeException;
 
 /**
  * Class Util
@@ -20,6 +21,7 @@ use CaptainHook\App\Storage\File\Json;
  * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
  * @link    https://github.com/captainhookphp/captainhook
  * @since   Class available since Release 1.0.3
+ * @internal
  */
 abstract class Util
 {
@@ -49,10 +51,10 @@ abstract class Util
     public static function validateHookConfig(array $json) : void
     {
         if (!self::keysExist(['enabled', 'actions'], $json)) {
-            throw new \RuntimeException('Config error: invalid hook configuration');
+            throw new RuntimeException('Config error: invalid hook configuration');
         }
         if (!is_array($json['actions'])) {
-            throw new \RuntimeException('Config error: \'actions\' must be an array');
+            throw new RuntimeException('Config error: \'actions\' must be an array');
         }
         self::validateActionsConfig($json['actions']);
     }
@@ -68,10 +70,10 @@ abstract class Util
     {
         foreach ($json as $action) {
             if (!self::keysExist(['action'], $action)) {
-                throw new \RuntimeException('Config error: \'action\' missing');
+                throw new RuntimeException('Config error: \'action\' missing');
             }
             if (empty($action['action'])) {
-                throw new \RuntimeException('Config error: \'action\' can\'t be empty');
+                throw new RuntimeException('Config error: \'action\' can\'t be empty');
             }
             if (!empty($action['conditions'])) {
                 self::validateConditionsConfig($action['conditions']);
@@ -89,10 +91,10 @@ abstract class Util
     {
         foreach ($json as $condition) {
             if (!self::keysExist(['exec'], $condition) || empty($condition['exec'])) {
-                throw new \RuntimeException('Config error: \'exec\' is required for conditions');
+                throw new RuntimeException('Config error: \'exec\' is required for conditions');
             }
             if (!empty($condition['args']) && !is_array($condition['args'])) {
-                throw new \RuntimeException('Config error: invalid \'args\' configuration');
+                throw new RuntimeException('Config error: invalid \'args\' configuration');
             }
         }
     }

--- a/tests/CaptainHook/Config/FactoryTest.php
+++ b/tests/CaptainHook/Config/FactoryTest.php
@@ -10,6 +10,7 @@
 namespace CaptainHook\App\Config;
 
 use CaptainHook\App\Config;
+use Exception;
 use PHPUnit\Framework\TestCase;
 
 class FactoryTest extends TestCase
@@ -73,5 +74,14 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(Config::class, $config);
         $this->assertTrue($config->getHookConfig('pre-commit')->isEnabled());
         $this->assertCount(2, $config->getHookConfig('pre-commit')->getActions());
+    }
+
+    /**
+     * Tests Factory::create
+     */
+    public function testCreateWithInvalidIncludes()
+    {
+        $this->expectException(Exception::class);
+        Factory::create(realpath(__DIR__ . '/../../files/config/valid-with-invalid-includes.json'));
     }
 }

--- a/tests/CaptainHook/Config/FactoryTest.php
+++ b/tests/CaptainHook/Config/FactoryTest.php
@@ -50,4 +50,28 @@ class FactoryTest extends TestCase
         $this->assertTrue($config->getHookConfig('pre-commit')->isEnabled());
         $this->assertCount(2, $config->getHookConfig('pre-commit')->getActions());
     }
+
+    /**
+     * Tests Factory::create
+     */
+    public function testCreateWithValidNestedIncludes()
+    {
+        $config = Factory::create(realpath(__DIR__ . '/../../files/config/valid-with-nested-includes.json'));
+
+        $this->assertInstanceOf(Config::class, $config);
+        $this->assertTrue($config->getHookConfig('pre-commit')->isEnabled());
+        $this->assertCount(3, $config->getHookConfig('pre-commit')->getActions());
+    }
+
+    /**
+     * Tests Factory::create
+     */
+    public function testCreateWithInvalidNestedIncludes()
+    {
+        $config = Factory::create(realpath(__DIR__ . '/../../files/config/invalid-with-nested-includes.json'));
+
+        $this->assertInstanceOf(Config::class, $config);
+        $this->assertTrue($config->getHookConfig('pre-commit')->isEnabled());
+        $this->assertCount(2, $config->getHookConfig('pre-commit')->getActions());
+    }
 }

--- a/tests/CaptainHook/Config/FactoryTest.php
+++ b/tests/CaptainHook/Config/FactoryTest.php
@@ -37,4 +37,17 @@ class FactoryTest extends TestCase
         $this->assertTrue($config->getHookConfig('pre-commit')->isEnabled());
         $this->assertCount(1, $config->getHookConfig('pre-commit')->getActions());
     }
+
+
+    /**
+     * Tests Factory::create
+     */
+    public function testCreateWithIncludes()
+    {
+        $config = Factory::create(realpath(__DIR__ . '/../../files/config/valid-with-includes.json'));
+
+        $this->assertInstanceOf(Config::class, $config);
+        $this->assertTrue($config->getHookConfig('pre-commit')->isEnabled());
+        $this->assertCount(2, $config->getHookConfig('pre-commit')->getActions());
+    }
 }

--- a/tests/CaptainHook/Config/HookTest.php
+++ b/tests/CaptainHook/Config/HookTest.php
@@ -18,7 +18,7 @@ class HookTest extends TestCase
      */
     public function testDisabledByDefault()
     {
-        $hook   = new Hook();
+        $hook   = new Hook('pre-commit');
         $config = $hook->getJsonData();
 
         $this->assertFalse($hook->isEnabled());
@@ -30,7 +30,7 @@ class HookTest extends TestCase
      */
     public function testSetEnabled()
     {
-        $hook   = new Hook();
+        $hook   = new Hook('pre-commit');
         $hook->setEnabled(true);
         $config = $hook->getJsonData();
 
@@ -43,7 +43,7 @@ class HookTest extends TestCase
      */
     public function testEmptyActions()
     {
-        $hook   = new Hook();
+        $hook   = new Hook('pre-commit');
         $config = $hook->getJsonData();
 
         $this->assertCount(0, $hook->getActions());
@@ -55,7 +55,7 @@ class HookTest extends TestCase
      */
     public function testAddAction()
     {
-        $hook   = new Hook();
+        $hook   = new Hook('pre-commit');
         $hook->addAction(new Action('\\Foo\\Bar'));
         $config = $hook->getJsonData();
 

--- a/tests/files/config/invalid-with-nested-includes.json
+++ b/tests/files/config/invalid-with-nested-includes.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "includes": [
+      "valid-include.json"
+    ]
+  },
+  "prepare-commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "pre-commit": {
+    "enabled": true,
+    "actions": [
+      {
+        "action": "phpunit --configuration=build/phpunit-hook.xml",
+        "options": []
+      }
+    ]
+  },
+  "pre-push": {
+    "enabled": false,
+    "actions": []
+  }
+}

--- a/tests/files/config/valid-include.json
+++ b/tests/files/config/valid-include.json
@@ -1,0 +1,23 @@
+{
+  "prepare-commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "pre-commit": {
+    "enabled": true,
+    "actions": [
+      {
+        "action": "phpcs --standard=psr2 src",
+        "options": []
+      }
+    ]
+  },
+  "pre-push": {
+    "enabled": false,
+    "actions": []
+  }
+}

--- a/tests/files/config/valid-nested-include.json
+++ b/tests/files/config/valid-nested-include.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "includes": [
+      "valid-include.json"
+    ]
+  },
+  "prepare-commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "pre-commit": {
+    "enabled": true,
+    "actions": [
+      {
+        "action": "phpcs --standard=psr2 src",
+        "options": []
+      }
+    ]
+  },
+  "pre-push": {
+    "enabled": false,
+    "actions": []
+  }
+}

--- a/tests/files/config/valid-with-includes.json
+++ b/tests/files/config/valid-with-includes.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "includes": [
+      "valid-include.json"
+    ]
+  },
+  "prepare-commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "pre-commit": {
+    "enabled": true,
+    "actions": [
+      {
+        "action": "phpunit --configuration=build/phpunit-hook.xml",
+        "options": []
+      }
+    ]
+  },
+  "pre-push": {
+    "enabled": false,
+    "actions": []
+  }
+}

--- a/tests/files/config/valid-with-invalid-includes.json
+++ b/tests/files/config/valid-with-invalid-includes.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "includes": [
+      "invalid-include.json"
+    ]
+  },
+  "prepare-commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "pre-commit": {
+    "enabled": true,
+    "actions": [
+      {
+        "action": "phpunit --configuration=build/phpunit-hook.xml",
+        "options": []
+      }
+    ]
+  },
+  "pre-push": {
+    "enabled": false,
+    "actions": []
+  }
+}

--- a/tests/files/config/valid-with-nested-includes.json
+++ b/tests/files/config/valid-with-nested-includes.json
@@ -1,0 +1,29 @@
+{
+  "config": {
+    "maxIncludeLevel": 2,
+    "includes": [
+      "valid-nested-include.json"
+    ]
+  },
+  "prepare-commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "pre-commit": {
+    "enabled": true,
+    "actions": [
+      {
+        "action": "phpunit --configuration=build/phpunit-hook.xml",
+        "options": []
+      }
+    ]
+  },
+  "pre-push": {
+    "enabled": false,
+    "actions": []
+  }
+}


### PR DESCRIPTION
Hi @heiglandreas 

Could you have a look at this, and let me know what you think?

This adds the possibility to include `CaptainHook` configurations in `CaptainHook` configuration files.
Basically it would look like this

```javascript
{
  "config": {
    "includes": [
      "vendor/my-company/hook-package/valid-include.json"
    ]
  },
  ...
  "pre-commit": {
    "enabled": true,
    "actions": [
      {
        "action": "phpunit --configuration=build/phpunit-hook.xml",
        "options": []
      }
    ]
  },
  ...
}
```

If the included configuration would look like this
```javascript
{
  "pre-commit": {
    "enabled": true,
    "actions": [
      {
        "action": "phpcs --standard=psr2 src",
        "options": []
      }
    ]
  }
}
```

and you run `CaptainHook` with the first configuration both `pre-commit` actions would be executed.

This way you could create  a "company base packages" that requires `CaptainHook` and maybe some plugins. Also the package could provide some base configurations that can be included in all project `captainhook.json` files.

This way if you want to add some validation to all projects the only thing you have to do is to update the package and run `composer update` on all projects.

I have not yet tested if a package can actually `require` a plugin, but I would hope that it's possible.
 