### PR TITLE
Allow black listed words within subject

### DIFF
--- a/src/Hook/Message/Rule/Blacklist.php
+++ b/src/Hook/Message/Rule/Blacklist.php
@@ -9,7 +9,11 @@
  */
 namespace CaptainHook\App\Hook\Message\Rule;
 
+use function array_map;
+use const PHP_EOL;
 use SebastianFeldmann\Git\CommitMessage;
+use function strpos;
+use function strtolower;
 
 /**
  * Class UseImperativeMood
@@ -125,12 +129,30 @@ class Blacklist extends Base
      */
     protected function containsBlacklistedWord(array $list, string $content) : bool
     {
+        return $this->compareContentAgainstWordListUsingCallback($content, $list, function ($content, $term) : bool {
+            return strpos($content, $term) !== false;
+        });
+    }
+
+    /**
+     * Contains blacklisted word
+     *
+     * Calable has to accept two parameters. The first is the string to check, the second is the string that is not
+     * supposed to be contained in the given string
+     *
+     * @param  array  $list
+     * @param  string $content
+     * @param callable $callable
+     * @return bool
+     */
+    protected function compareContentAgainstWordListUsingCallback(string $content, array $list, Callable $callable) : bool
+    {
         if (!$this->isCaseSensitive) {
             $content = strtolower($content);
             $list    = array_map('strtolower', $list);
         }
         foreach ($list as $term) {
-            if (strpos($content, $term) !== false) {
+            if ($callable($content, $term)) {
                 $this->hint .= PHP_EOL . 'Invalid use of \'' . $term . '\'';
                 return true;
             }

--- a/src/Hook/Message/Rule/UseImperativeMood.php
+++ b/src/Hook/Message/Rule/UseImperativeMood.php
@@ -9,6 +9,8 @@
  */
 namespace CaptainHook\App\Hook\Message\Rule;
 
+use function strpos;
+
 /**
  * Class UseImperativeMood
  *
@@ -19,11 +21,13 @@ namespace CaptainHook\App\Hook\Message\Rule;
  */
 class UseImperativeMood extends Blacklist
 {
+    private $checkOnlyBeginning;
     /**
      * Constructor
      */
-    public function __construct()
+    public function __construct($checkOnlyBeginning = false)
     {
+        $this->checkOnlyBeginning = $checkOnlyBeginning;
         parent::__construct(false);
         $this->hint = 'Subject should be written in imperative mood';
         $this->setSubjectBlacklist(
@@ -38,4 +42,17 @@ class UseImperativeMood extends Blacklist
             ]
         );
     }
+
+    protected function containsBlacklistedWord(array $list, string $content) : bool
+    {
+        if ($this->checkOnlyBeginning === true) {
+            return $this->compareContentAgainstWordListUsingCallback($content, $list, function ($content, $term): bool {
+                return strpos($content, $term) === 0;
+            });
+        }
+
+        return parent::containsBlacklistedWord($list, $content);
+    }
+
+
 }

--- a/src/Hook/Message/RuleBook/RuleSet.php
+++ b/src/Hook/Message/RuleBook/RuleSet.php
@@ -34,7 +34,7 @@ abstract class RuleSet
             new Rule\CapitalizeSubject(),
             new Rule\LimitSubjectLength($subjectLength),
             new Rule\NoPeriodOnSubjectEnd(),
-            new Rule\UseImperativeMood(),
+            new Rule\UseImperativeMood(true),
             new Rule\LimitBodyLineLength($bodyLineLength),
             new Rule\SeparateSubjectFromBodyWithBlankLine()
         ];

--- a/tests/CaptainHook/Hook/Message/Rule/UseImperativeMoodTest.php
+++ b/tests/CaptainHook/Hook/Message/Rule/UseImperativeMoodTest.php
@@ -16,27 +16,26 @@ class UseImperativeMoodTest extends TestCase
 {
     /**
      * Tests UseImperativeMood::pass
+     *
+     * @dataProvider passProvider
      */
-    public function testPassSuccess()
+    public function testPass(string $string, bool $begin, bool $expectedResult)
     {
-        $msg  = new CommitMessage('Foo bar baz');
-        $rule = new UseImperativeMood();
+        $msg  = new CommitMessage($string);
+        $rule = new UseImperativeMood($begin);
 
-        $this->assertTrue($rule->pass($msg));
+        $this->assertSame($expectedResult, $rule->pass($msg));
     }
 
-    /**
-     * Tests UseImperativeMood::pass
-     */
-    public function testPassFail()
+    public function passProvider() : array
     {
-        $msg  = new CommitMessage('Added some something');
-        $rule = new UseImperativeMood();
-
-        $this->assertFalse($rule->pass($msg));
-
-        $hint = $rule->getHint();
-
-        $this->assertTrue((bool) strpos($hint, 'imperative'));
+        return [
+            ['foo bar baz', true, true],
+            ['foo bar baz', false, true],
+            ['fixed soemthing something', false, false],
+            ['fixed soemthing something', true, false],
+            ['soemthing fixed something', false, false],
+            ['soemthing fixed something', true, true],
+        ];
     }
 }


### PR DESCRIPTION
This allows the use of blacklisted words within the subject and only fails when they are found at the beginning of the subject. This only applies to using the beams-rule