### PR TITLE
[WIP] Allow included configurations to enable hooks

### DIFF
--- a/src/Config/Factory.php
+++ b/src/Config/Factory.php
@@ -100,13 +100,13 @@ final class Factory
         $json = $file->readAssoc();
         Util::validateJsonConfiguration($json);
 
+        $this->appendIncludedConfigurations($config, $json);
+
         foreach (HookUtil::getValidHooks() as $hook => $class) {
             if (isset($json[$hook])) {
                 $this->configureHook($config->getHookConfig($hook), $json[$hook]);
             }
         }
-
-        $this->appendIncludedConfigurations($config, $json);
     }
 
     /**

--- a/src/Config/Factory.php
+++ b/src/Config/Factory.php
@@ -144,7 +144,7 @@ final class Factory
         if ($this->includeLevel < $this->maxIncludeLevel) {
             $includes = $this->loadIncludedConfigs($json, $config->getPath());
             foreach (HookUtil::getValidHooks() as $hook => $class) {
-                $this->appendHookActionsFromIncludes($config->getHookConfig($hook), $includes);
+                $this->mergeHookConfigFromIncludes($config->getHookConfig($hook), $includes);
             }
         }
         $this->includeLevel++;
@@ -164,16 +164,20 @@ final class Factory
     }
 
     /**
-     * Append actions to a given hook config from a list of included configurations
+     * Merge a given hook config with the corresponding hook configs from a list of included configurations
      *
      * @param  \CaptainHook\App\Config\Hook $hook
      * @param  \CaptainHook\App\Config[]    $includes
      * @return void
      */
-    private function appendHookActionsFromIncludes(Hook $hook, array $includes) : void
+    private function mergeHookConfigFromIncludes(Hook $hook, array $includes) : void
     {
         foreach ($includes as $includedConfig) {
-            $this->copyActionsFromTo($includedConfig->getHookConfig($hook->getName()), $hook);
+            $includedHook = $includedConfig->getHookConfig($hook->getName());
+            if ($includedHook->isEnabled()) {
+                $hook->setEnabled(true);
+            }
+            $this->copyActionsFromTo($includedHook, $hook);
         }
     }
 

--- a/tests/CaptainHook/Config/FactoryTest.php
+++ b/tests/CaptainHook/Config/FactoryTest.php
@@ -84,4 +84,16 @@ class FactoryTest extends TestCase
         $this->expectException(Exception::class);
         Factory::create(realpath(__DIR__ . '/../../files/config/valid-with-invalid-includes.json'));
     }
+
+    /**
+     * Tests Factory::create
+     */
+    public function testCreateEmptyWithIncludes()
+    {
+        $config = Factory::create(realpath(__DIR__ . '/../../files/config/empty-with-includes.json'));
+
+        $this->assertInstanceOf(Config::class, $config);
+        $this->assertTrue($config->getHookConfig('pre-commit')->isEnabled());
+        $this->assertCount(1, $config->getHookConfig('pre-commit')->getActions());
+    }
 }

--- a/tests/CaptainHook/Config/FactoryTest.php
+++ b/tests/CaptainHook/Config/FactoryTest.php
@@ -96,4 +96,15 @@ class FactoryTest extends TestCase
         $this->assertTrue($config->getHookConfig('pre-commit')->isEnabled());
         $this->assertCount(1, $config->getHookConfig('pre-commit')->getActions());
     }
+
+    /**
+     * Tests Factory::create
+     */
+    public function testWithMainConfigurationOverridingInclude()
+    {
+        $config = Factory::create(realpath(__DIR__ . '/../../files/config/valid-with-disabled-action.json'));
+
+        $this->assertInstanceOf(Config::class, $config);
+        $this->assertFalse($config->getHookConfig('pre-commit')->isEnabled());
+    }
 }

--- a/tests/files/config/empty-with-includes.json
+++ b/tests/files/config/empty-with-includes.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "includes": [
+      "valid-include.json"
+    ]
+  }
+}

--- a/tests/files/config/valid-with-disabled-action.json
+++ b/tests/files/config/valid-with-disabled-action.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "includes": [
+      "valid-include.json"
+    ]
+  },
+  "pre-commit": {
+    "enabled": false,
+    "actions": []
+  }
+}


### PR DESCRIPTION
Consider this a rough draft to get some feedback on the idea, not a finished and polished implementation.

Right now, one can add extra actions through included configurations. If an included configuration has `"enabled": true` for some hook, that does not mean that hook is automatically enabled in the merged configuration. That means that when you use an included config, you still need to know what hooks that config defines and enable them. This PR also merges the `enabled`-flag from included configurations, so the latter is not necessary anymore. If either the main configuration or an included configuration has `"enabled": true`, that hook is enabled. 

I can image that it is slightly 'spooky' to have an included configuration enable a hook like this, therefore I'm first posting a rough version to get some feedback on the idea. One additional improvement could be to let the `enabled`-flags in the main configuration override any `enabled`-flags in included configurations. That way having `"enabled": false` in the main config would absolutely ensure that hook is disabled.

What do you think?