### PR TITLE
Pass run-mode into Template\Builder from Command\Install

### DIFF
--- a/src/Console/Command/Install.php
+++ b/src/Console/Command/Install.php
@@ -107,7 +107,7 @@ class Install extends Base
         $installer = new Installer($io, $config, $repo);
         $installer->setForce(IOUtil::argToBool($input->getOption('force')))
                   ->setHook(IOUtil::argToString($input->getArgument('hook')))
-                  ->setTemplate(Template\Builder::build($input, $config, $repo))
+                  ->setTemplate(Template\Builder::build($input, $config, $repo, $runMode))
                   ->run();
 
         return 0;

--- a/src/Hook/Template/Builder.php
+++ b/src/Hook/Template/Builder.php
@@ -36,12 +36,18 @@ abstract class Builder
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \CaptainHook\App\Config                         $config
      * @param \SebastianFeldmann\Git\Repository               $repository
+     * @param string                                          $runMode
      *
      * @return \CaptainHook\App\Hook\Template
      */
-    public static function build(InputInterface $input, Config $config, Repository $repository): Template
+    public static function build(
+        InputInterface $input,
+        Config $config,
+        Repository $repository,
+        string $runMode
+    ): Template
     {
-        if ($input->getOption(Config::SETTING_RUN_MODE) === Template::DOCKER) {
+        if ($runMode === Template::DOCKER) {
             // For docker we need to strip down the current working directory.
             // This is caused because docker will always connect to a specific working directory
             // where the absolute path will not be recognized.

--- a/tests/CaptainHook/Hook/Template/BuilderTest.php
+++ b/tests/CaptainHook/Hook/Template/BuilderTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace CaptainHook\App\Hook\Template;
 
 use CaptainHook\App\Config;
+use CaptainHook\App\Hook\Template;
 use PHPUnit\Framework\TestCase;
 use SebastianFeldmann\Git\Repository;
 use Symfony\Component\Console\Input\InputInterface;
@@ -33,7 +34,7 @@ class BuilderTest extends TestCase
         $repository = $this->prophesize(Repository::class);
         $repository->getRoot()->willReturn(CH_PATH_FILES . '/config');
 
-        $template = Builder::build($input->reveal(), $config->reveal(), $repository->reveal());
+        $template = Builder::build($input->reveal(), $config->reveal(), $repository->reveal(), Template::DOCKER);
         $this->assertInstanceOf(Docker::class, $template);
 
         $code = $template->getCode('pre-commit');
@@ -55,7 +56,7 @@ class BuilderTest extends TestCase
         $repository = $this->prophesize(Repository::class);
         $repository->getRoot()->willReturn(CH_PATH_FILES . '/config');
 
-        $template = Builder::build($input->reveal(), $config->reveal(), $repository->reveal());
+        $template = Builder::build($input->reveal(), $config->reveal(), $repository->reveal(), Template::LOCAL);
         $this->assertInstanceOf(Local::class, $template);
 
         $code = $template->getCode('pre-commit');


### PR DESCRIPTION
Because run-mode can be set in configuration, we need to check config too.
I updated Template\Builder so run-mode is passed via parameter.
Run-mode could be resolved again from input and config in builder without
the additional parameter but i felt like that would violate DRY.