### PR TITLE
Fix docker-setup with configuration file

### DIFF
--- a/src/Console/Command/Install.php
+++ b/src/Console/Command/Install.php
@@ -107,7 +107,7 @@ class Install extends Base
         $installer = new Installer($io, $config, $repo);
         $installer->setForce(IOUtil::argToBool($input->getOption('force')))
                   ->setHook(IOUtil::argToString($input->getArgument('hook')))
-                  ->setTemplate(Template\Builder::build($input, $config, $repo, $runMode))
+                  ->setTemplate(Template\Builder::build($input, $config, $repo))
                   ->run();
 
         return 0;

--- a/tests/CaptainHook/Hook/Template/BuilderTest.php
+++ b/tests/CaptainHook/Hook/Template/BuilderTest.php
@@ -29,12 +29,36 @@ class BuilderTest extends TestCase
         $input->getOption('run-exec')->willReturn('docker exec captain-container');
 
         $config = $this->prophesize(Config::class);
+        $config->getRunMode()->willReturn('local');
+        $config->getRunExec()->willReturn('');
         $config->getPath()->willReturn(CH_PATH_FILES . '/config/valid.json');
 
         $repository = $this->prophesize(Repository::class);
         $repository->getRoot()->willReturn(CH_PATH_FILES . '/config');
 
         $template = Builder::build($input->reveal(), $config->reveal(), $repository->reveal(), Template::DOCKER);
+        $this->assertInstanceOf(Docker::class, $template);
+
+        $code = $template->getCode('pre-commit');
+        $this->assertStringContainsString('pre-commit', $code);
+        $this->assertStringContainsString('docker exec captain-container', $code);
+    }
+
+    public function testBuildDockerTemplateObservesConfig(): void
+    {
+        $input = $this->prophesize(InputInterface::class);
+        $input->getOption('run-mode')->willReturn('');
+        $input->getOption('run-exec')->willReturn('');
+
+        $config = $this->prophesize(Config::class);
+        $config->getRunMode()->willReturn('docker');
+        $config->getRunExec()->willReturn('docker exec captain-container');
+        $config->getPath()->willReturn(CH_PATH_FILES . '/config/valid.json');
+
+        $repository = $this->prophesize(Repository::class);
+        $repository->getRoot()->willReturn(CH_PATH_FILES . '/config');
+
+        $template = Builder::build($input->reveal(), $config->reveal(), $repository->reveal());
         $this->assertInstanceOf(Docker::class, $template);
 
         $code = $template->getCode('pre-commit');
@@ -51,6 +75,8 @@ class BuilderTest extends TestCase
         $input->getOption('run-mode')->willReturn('local');
 
         $config = $this->prophesize(Config::class);
+        $config->getRunMode()->willReturn('local');
+        $config->getRunExec()->willReturn('');
         $config->getPath()->willReturn(CH_PATH_FILES . '/config/valid.json');
 
         $repository = $this->prophesize(Repository::class);


### PR DESCRIPTION
This commit fixes that the setup reads the docker-setup configuration
from the captainhook.json config file.

Currently the docker config can only be setup using the commandline
arguments on the `captainhook install` command. But for existing or new
setups where the configuration file is distributed that is not the
expected behaviour. The problem was that the Builder currently only
checks for the command-line options but ignores the configuration
option. The new behaviour also checks the config options and uses them
when no commandline arguments are passed. Therefore installations using
the captainhook composer plugin now will be able to install the docker
based setup from the commited config-file