### PR TITLE
Replace DummyOutput with NullOutput

### DIFF
--- a/tests/CaptainHook/Console/Command/AddTest.php
+++ b/tests/CaptainHook/Console/Command/AddTest.php
@@ -12,8 +12,8 @@ namespace CaptainHook\App\Console\Command;
 use CaptainHook\App\Console\IO\DefaultIO;
 use CaptainHook\App\Console\IO\NullIO;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
 
 class AddTest extends TestCase
 {
@@ -30,7 +30,7 @@ class AddTest extends TestCase
                 '--configuration' => 'foo'
             ]
         );
-        $output  = new DummyOutput();
+        $output  = new NullOutput();
         $install = new Add();
         $install->setIO(new NullIO());
         $install->run($input, $output);
@@ -46,7 +46,7 @@ class AddTest extends TestCase
 
 
         $add    = new Add();
-        $output = new DummyOutput();
+        $output = new NullOutput();
         $input  = new ArrayInput(
             [
                 'hook'            => 'pre-commit',

--- a/tests/CaptainHook/Console/Command/ConfigurationTest.php
+++ b/tests/CaptainHook/Console/Command/ConfigurationTest.php
@@ -11,7 +11,7 @@ namespace CaptainHook\App\Console\Command;
 
 use CaptainHook\App\Console\IO\NullIO;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
+use Symfony\Component\Console\Output\NullOutput;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationTest extends TestCase
@@ -23,7 +23,7 @@ class ConfigurationTest extends TestCase
     {
         $config    = sys_get_temp_dir() . DIRECTORY_SEPARATOR . md5(mt_rand(0, 9999)) . '.json';
         $configure = new Configuration();
-        $output    = new DummyOutput();
+        $output    = new NullOutput();
         $input     = new ArrayInput(['--configuration' => $config]);
 
         $configure->setIO(new NullIO());

--- a/tests/CaptainHook/Console/Command/DisableTest.php
+++ b/tests/CaptainHook/Console/Command/DisableTest.php
@@ -12,8 +12,8 @@ namespace CaptainHook\App\Console\Command;
 use CaptainHook\App\Console\IO\DefaultIO;
 use CaptainHook\App\Console\IO\NullIO;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
 
 class DisableTest extends TestCase
 {
@@ -30,7 +30,7 @@ class DisableTest extends TestCase
                 '--configuration' => 'foo'
             ]
         );
-        $output  = new DummyOutput();
+        $output  = new NullOutput();
         $install = new Disable();
         $install->setIO(new NullIO());
         $install->run($input, $output);
@@ -46,7 +46,7 @@ class DisableTest extends TestCase
 
 
         $add    = new Disable();
-        $output = new DummyOutput();
+        $output = new NullOutput();
         $input  = new ArrayInput(
             [
                 'hook'            => 'pre-commit',

--- a/tests/CaptainHook/Console/Command/EnableTest.php
+++ b/tests/CaptainHook/Console/Command/EnableTest.php
@@ -11,12 +11,13 @@ namespace CaptainHook\App\Console\Command;
 
 use CaptainHook\App\Console\IO\DefaultIO;
 use CaptainHook\App\Console\IO\NullIO;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 class EnableTest extends TestCase
 {
+
     /**
      * Tests Enable::run
      */
@@ -24,13 +25,11 @@ class EnableTest extends TestCase
     {
         $this->expectException(\Exception::class);
 
-        $input   = new ArrayInput(
-            [
+        $input = new ArrayInput([
                 'hook' => 'pre-commit',
-                '--configuration' => 'foo'
-            ]
-        );
-        $output  = new DummyOutput();
+                '--configuration' => 'foo',
+            ]);
+        $output = new NullOutput();
         $install = new Enable();
         $install->setIO(new NullIO());
         $install->run($input, $output);
@@ -44,15 +43,12 @@ class EnableTest extends TestCase
         $config = sys_get_temp_dir() . '/captainhook-enable.json';
         copy(CH_PATH_FILES . '/config/valid.json', $config);
 
-
-        $add    = new Enable();
-        $output = new DummyOutput();
-        $input  = new ArrayInput(
-            [
-                'hook'            => 'pre-push',
-                '--configuration' => $config
-            ]
-        );
+        $add = new Enable();
+        $output = new NullOutput();
+        $input = new ArrayInput([
+                'hook' => 'pre-push',
+                '--configuration' => $config,
+            ]);
 
         $io = $this->getMockBuilder(DefaultIO::class)
                    ->disableOriginalConstructor()

--- a/tests/CaptainHook/Console/Command/Hook/CommitMsgTest.php
+++ b/tests/CaptainHook/Console/Command/Hook/CommitMsgTest.php
@@ -12,7 +12,7 @@ namespace CaptainHook\App\Console\Command\Hook;
 use CaptainHook\App\Console\IO\NullIO;
 use CaptainHook\App\Git\DummyRepo;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
+use Symfony\Component\Console\Output\NullOutput;
 use PHPUnit\Framework\TestCase;
 
 class CommitMsgTest extends TestCase
@@ -30,7 +30,7 @@ class CommitMsgTest extends TestCase
         $repo->setup();
 
         $cmd    = new CommitMsg(CH_PATH_FILES . '/config/valid.json', $repo->getPath());
-        $output = new DummyOutput();
+        $output = new NullOutput();
         $input  = new ArrayInput(
             [
                 'file' => CH_PATH_FILES . '/git/message/valid.txt'

--- a/tests/CaptainHook/Console/Command/Hook/PostCheckoutTest.php
+++ b/tests/CaptainHook/Console/Command/Hook/PostCheckoutTest.php
@@ -12,7 +12,7 @@ namespace CaptainHook\App\Console\Command\Hook;
 use CaptainHook\App\Console\IO\NullIO;
 use CaptainHook\App\Git\DummyRepo;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
+use Symfony\Component\Console\Output\NullOutput;
 use PHPUnit\Framework\TestCase;
 
 class PostCheckoutTest extends TestCase
@@ -30,7 +30,7 @@ class PostCheckoutTest extends TestCase
         $repo->setup();
 
         $cmd    = new PostCheckout(CH_PATH_FILES . '/config/empty.json', $repo->getPath());
-        $output = new DummyOutput();
+        $output = new NullOutput();
         $input  = new ArrayInput([]);
 
         $cmd->setIO(new NullIO());

--- a/tests/CaptainHook/Console/Command/Hook/PostCommitTest.php
+++ b/tests/CaptainHook/Console/Command/Hook/PostCommitTest.php
@@ -12,7 +12,7 @@ namespace CaptainHook\App\Console\Command\Hook;
 use CaptainHook\App\Console\IO\NullIO;
 use CaptainHook\App\Git\DummyRepo;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
+use Symfony\Component\Console\Output\NullOutput;
 use PHPUnit\Framework\TestCase;
 
 class PostCommitTest extends TestCase
@@ -30,7 +30,7 @@ class PostCommitTest extends TestCase
         $repo->setup();
 
         $cmd    = new PostCommit(CH_PATH_FILES . '/config/empty.json', $repo->getPath());
-        $output = new DummyOutput();
+        $output = new NullOutput();
         $input  = new ArrayInput([]);
 
         $cmd->setIO(new NullIO());

--- a/tests/CaptainHook/Console/Command/Hook/PostMergeTest.php
+++ b/tests/CaptainHook/Console/Command/Hook/PostMergeTest.php
@@ -12,7 +12,7 @@ namespace CaptainHook\App\Console\Command\Hook;
 use CaptainHook\App\Console\IO\NullIO;
 use CaptainHook\App\Git\DummyRepo;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
+use Symfony\Component\Console\Output\NullOutput;
 use PHPUnit\Framework\TestCase;
 
 class PostMergeTest extends TestCase
@@ -30,7 +30,7 @@ class PostMergeTest extends TestCase
         $repo->setup();
 
         $cmd    = new PostMerge(CH_PATH_FILES . '/config/empty.json', $repo->getPath());
-        $output = new DummyOutput();
+        $output = new NullOutput();
         $input  = new ArrayInput(
             [
                 'squash' => 0

--- a/tests/CaptainHook/Console/Command/Hook/PreCommitTest.php
+++ b/tests/CaptainHook/Console/Command/Hook/PreCommitTest.php
@@ -12,7 +12,7 @@ namespace CaptainHook\App\Console\Command\Hook;
 use CaptainHook\App\Console\IO\NullIO;
 use CaptainHook\App\Git\DummyRepo;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
+use Symfony\Component\Console\Output\NullOutput;
 use PHPUnit\Framework\TestCase;
 
 class PreCommitTest extends TestCase
@@ -30,7 +30,7 @@ class PreCommitTest extends TestCase
         $repo->setup();
 
         $cmd    = new PreCommit(CH_PATH_FILES . '/config/empty.json', $repo->getPath());
-        $output = new DummyOutput();
+        $output = new NullOutput();
         $input  = new ArrayInput([]);
 
         $cmd->setIO(new NullIO());

--- a/tests/CaptainHook/Console/Command/Hook/PrePushTest.php
+++ b/tests/CaptainHook/Console/Command/Hook/PrePushTest.php
@@ -12,7 +12,7 @@ namespace CaptainHook\App\Console\Command\Hook;
 use CaptainHook\App\Console\IO\NullIO;
 use CaptainHook\App\Git\DummyRepo;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
+use Symfony\Component\Console\Output\NullOutput;
 use PHPUnit\Framework\TestCase;
 
 class PrePushTest extends TestCase
@@ -30,7 +30,7 @@ class PrePushTest extends TestCase
         $repo->setup();
 
         $cmd    = new PrePush(CH_PATH_FILES . '/config/empty.json', $repo->getPath());
-        $output = new DummyOutput();
+        $output = new NullOutput();
         $input  = new ArrayInput([]);
 
         $cmd->setIO(new NullIO());

--- a/tests/CaptainHook/Console/Command/Hook/PrepareCommitMsgTest.php
+++ b/tests/CaptainHook/Console/Command/Hook/PrepareCommitMsgTest.php
@@ -12,8 +12,8 @@ namespace CaptainHook\App\Console\Command\Hook;
 use CaptainHook\App\Console\IO\NullIO;
 use CaptainHook\App\Git\DummyRepo;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
 
 class PrepareCommitMsgTest extends TestCase
 {
@@ -30,7 +30,7 @@ class PrepareCommitMsgTest extends TestCase
         $repo->setup();
 
         $cmd    = new PrepareCommitMsg(CH_PATH_FILES . '/config/valid.json', $repo->getPath());
-        $output = new DummyOutput();
+        $output = new NullOutput();
         $input  = new ArrayInput(
             [
                 'file' => CH_PATH_FILES . '/git/message/valid.txt',

--- a/tests/CaptainHook/Console/Command/InstallTest.php
+++ b/tests/CaptainHook/Console/Command/InstallTest.php
@@ -14,8 +14,8 @@ use CaptainHook\App\Git\DummyRepo;
 use CaptainHook\App\Hook\Template;
 use Exception;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Tests\Fixtures\DummyOutput;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
 
 class InstallTest extends TestCase
 {
@@ -27,7 +27,7 @@ class InstallTest extends TestCase
         $this->expectException(Exception::class);
 
         $install = new Install();
-        $output  = new DummyOutput();
+        $output  = new NullOutput();
         $input   = new ArrayInput(
             [
                 'hook'            => 'pre-commit',
@@ -47,7 +47,7 @@ class InstallTest extends TestCase
         $this->expectException(Exception::class);
 
         $install = new Install();
-        $output  = new DummyOutput();
+        $output  = new NullOutput();
         $input   = new ArrayInput(
             [
                 'hook'            => 'pre-commit',
@@ -75,7 +75,7 @@ class InstallTest extends TestCase
 
         try {
             $install = new Install();
-            $output  = new DummyOutput();
+            $output  = new NullOutput();
             $input   = new ArrayInput(
                 [
                     'hook'            => 'pre-commit',
@@ -109,7 +109,7 @@ class InstallTest extends TestCase
         $repo->setup();
 
         $install = new Install();
-        $output  = new DummyOutput();
+        $output  = new NullOutput();
         $input   = new ArrayInput(
             [
                 'hook'            => 'pre-commit',


### PR DESCRIPTION
Hello, 

in symfony/console 4.4 .gitattributes file was added https://github.com/symfony/console/commit/c35a2fc5bd760385b234aee5d231aeb90d7f3741
and DummyOutput is now not shipped in composer, so i replaced DummyOutput with NullOutput for tests to pass.

#SymfonyHackday