### PR TITLE
Any/All conditions accept wildcards in filenames

### DIFF
--- a/src/Hook/Condition/FileChanged/All.php
+++ b/src/Hook/Condition/FileChanged/All.php
@@ -50,8 +50,16 @@ class All extends FileChanged
      */
     private function didAllFilesChange(array $changedFiles): bool
     {
-        foreach ($this->filesToWatch as $file) {
-            if (!in_array($file, $changedFiles)) {
+        foreach ($this->filesToWatch as $filePattern) {
+            $foundPattern = false;
+            foreach($changedFiles as $changedFile) {
+                if (fnmatch($filePattern, $changedFile)) {
+                    $foundPattern = true;
+                    break;
+                }
+            }
+
+            if(!$foundPattern) {
                 return false;
             }
         }

--- a/src/Hook/Condition/FileChanged/Any.php
+++ b/src/Hook/Condition/FileChanged/Any.php
@@ -64,9 +64,11 @@ class Any extends FileChanged
      */
     private function didAnyFileChange(array $changedFiles): bool
     {
-        foreach ($this->filesToWatch as $file) {
-            if (in_array($file, $changedFiles)) {
-                return true;
+        foreach ($this->filesToWatch as $filePattern) {
+            foreach($changedFiles as $changedFile) {
+                if (fnmatch($filePattern, $changedFile)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/tests/CaptainHook/Hook/Condition/FileChanged/AllTest.php
+++ b/tests/CaptainHook/Hook/Condition/FileChanged/AllTest.php
@@ -39,6 +39,22 @@ class AllTest extends TestCase
     /**
      * Tests All::isTrue
      */
+    public function testWithWildcardIsFalse(): void
+    {
+        $io = $this->createIOMock();
+        $io->expects($this->exactly(2))->method('getArgument')->willReturn('');
+        $operator   = $this->createGitDiffOperator(['fiz.php', 'baz.php', 'foo.php']);
+        $repository = $this->createRepositoryMock('');
+        $repository->expects($this->once())->method('getDiffOperator')->willReturn($operator);
+
+        $fileChange = new All(['foo.*', 'bar.php']);
+
+        $this->assertFalse($fileChange->isTrue($io, $repository));
+    }
+
+    /**
+     * Tests All::isTrue
+     */
     public function testIsTrue(): void
     {
         $io = $this->createIOMock();
@@ -48,6 +64,22 @@ class AllTest extends TestCase
         $repository->expects($this->once())->method('getDiffOperator')->willReturn($operator);
 
         $fileChange = new All(['foo.php', 'bar.php']);
+
+        $this->assertTrue($fileChange->isTrue($io, $repository));
+    }
+
+    /**
+     * Tests All::isTrue
+     */
+    public function testWithWildcardIsTrue(): void
+    {
+        $io = $this->createIOMock();
+        $io->expects($this->exactly(2))->method('getArgument')->willReturn('');
+        $operator   = $this->createGitDiffOperator(['foo.php', 'bar.php', 'baz.php']);
+        $repository = $this->createRepositoryMock('');
+        $repository->expects($this->once())->method('getDiffOperator')->willReturn($operator);
+
+        $fileChange = new All(['foo.*', 'ba?.php']);
 
         $this->assertTrue($fileChange->isTrue($io, $repository));
     }

--- a/tests/CaptainHook/Hook/Condition/FileChanged/AnyTest.php
+++ b/tests/CaptainHook/Hook/Condition/FileChanged/AnyTest.php
@@ -50,6 +50,22 @@ class AnyTest extends TestCase
     /**
      * Tests Any::isTrue
      */
+    public function testWithWildcardIsTrue(): void
+    {
+        $io = $this->createIOMock();
+        $io->expects($this->exactly(2))->method('getArgument')->willReturn('');
+        $operator   = $this->createGitDiffOperator(['fiz.php', 'baz.php', 'foo.php']);
+        $repository = $this->createRepositoryMock('');
+        $repository->expects($this->once())->method('getDiffOperator')->willReturn($operator);
+
+        $fileChange = new Any(['foo.*', 'bar.php']);
+
+        $this->assertTrue($fileChange->isTrue($io, $repository));
+    }
+
+    /**
+     * Tests Any::isTrue
+     */
     public function testIsFalse(): void
     {
         $io = $this->createIOMock();
@@ -59,6 +75,22 @@ class AnyTest extends TestCase
         $repository->expects($this->once())->method('getDiffOperator')->willReturn($operator);
 
         $fileChange = new Any(['foo.php', 'bar.php']);
+
+        $this->assertFalse($fileChange->isTrue($io, $repository));
+    }
+
+    /**
+     * Tests Any::isTrue
+     */
+    public function testWithWildcardIsFalse(): void
+    {
+        $io = $this->createIOMock();
+        $io->expects($this->exactly(2))->method('getArgument')->willReturn('');
+        $operator   = $this->createGitDiffOperator(['fiz.php', 'baz.php']);
+        $repository = $this->createRepositoryMock('');
+        $repository->expects($this->once())->method('getDiffOperator')->willReturn($operator);
+
+        $fileChange = new Any(['fo?.php', 'bar.*']);
 
         $this->assertFalse($fileChange->isTrue($io, $repository));
     }


### PR DESCRIPTION
Fixes #66. Replace in_array() check with fnmatch() to allow wildcards e.g. foo.* or ba?.php in filenames.