### PR TITLE
Add fail-at-first-error config setting

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -24,15 +24,16 @@ use SebastianFeldmann\Camino\Check;
  */
 class Config
 {
-    public const SETTING_BOOTSTRAP      = 'bootstrap';
-    public const SETTING_COLORS         = 'ansi-colors';
-    public const SETTING_GIT_DIR        = 'git-directory';
-    public const SETTING_INCLUDES       = 'includes';
-    public const SETTING_INCLUDES_LEVEL = 'includes-level';
-    public const SETTING_RUN_EXEC       = 'run-exec';
-    public const SETTING_RUN_MODE       = 'run-mode';
-    public const SETTING_RUN_PATH       = 'run-path';
-    public const SETTING_VERBOSITY      = 'verbosity';
+    public const SETTING_BOOTSTRAP           = 'bootstrap';
+    public const SETTING_COLORS              = 'ansi-colors';
+    public const SETTING_GIT_DIR             = 'git-directory';
+    public const SETTING_INCLUDES            = 'includes';
+    public const SETTING_INCLUDES_LEVEL      = 'includes-level';
+    public const SETTING_RUN_EXEC            = 'run-exec';
+    public const SETTING_RUN_MODE            = 'run-mode';
+    public const SETTING_RUN_PATH            = 'run-path';
+    public const SETTING_VERBOSITY           = 'verbosity';
+    public const SETTING_FAIL_AT_FIRST_ERROR = 'fail-at-first-error';
 
     /**
      * Path to the config file
@@ -179,6 +180,18 @@ class Config
     public function getRunPath(): string
     {
         return (string) ($this->settings[self::SETTING_RUN_PATH] ?? '');
+    }
+
+    /**
+     * Whether to abort the hook as soon as a any action has errored. Default is true.
+     * Otherwise, all actions get executed (even if some of them have failed) and
+     * finally, a non-zero exit code is returned if any action has errored.
+     *
+     * @return bool
+     */
+    public function failAtFirstError(): bool
+    {
+        return (bool) ($this->settings[self::SETTING_FAIL_AT_FIRST_ERROR] ?? true);
     }
 
     /**

--- a/src/Runner/Hook.php
+++ b/src/Runner/Hook.php
@@ -14,6 +14,7 @@ namespace CaptainHook\App\Runner;
 use CaptainHook\App\Config;
 use CaptainHook\App\Console\IO;
 use CaptainHook\App\Console\IOUtil;
+use CaptainHook\App\Exception\ActionFailed;
 use RuntimeException;
 
 /**
@@ -98,11 +99,61 @@ abstract class Hook extends RepositoryAware
             $this->io->write(['', '<info>No actions to execute</info>'], true, IO::VERBOSE);
             return;
         }
+
         $this->beforeHook();
-        foreach ($actions as $action) {
-            $this->handleAction($action);
+
+        if ($this->config->failAtFirstError()) {
+            $this->executeFailAtFirstError($actions);
+        } else {
+            $this->executeFailAfterAllActions($actions);
         }
+
         $this->afterHook();
+    }
+
+    /**
+     * Executes all actions. If any of them failes, immediately throws an ActionFailed exception.
+     *
+     * @param  \CaptainHook\App\Config\Action[] $actions
+     * @return void
+     * @throws \Exception
+     */
+    protected function executeFailAtFirstError(array $actions): void
+    {
+        foreach ($actions as $action) {
+            try {
+                $this->handleAction($action);
+            } catch (ActionFailed $exception) {
+                $this->io->write($exception->getMessage());
+                throw new ActionFailed('Action failed; please see above error messages');
+            }
+        }
+    }
+
+    /**
+     * Executes all actions. Eventuelly throws an ActionFailed exception if any action has failed.
+     * This method makes sure that all actions are executed, without regarding whether previous actions have failed.
+     *
+     * @param  \CaptainHook\App\Config\Action[] $actions
+     * @return void
+     * @throws \Exception
+     */
+    protected function executeFailAfterAllActions(array $actions): void
+    {
+        $failedActions = 0;
+
+        foreach ($actions as $action) {
+            try {
+                $this->handleAction($action);
+            } catch (ActionFailed $exception) {
+                $this->io->write($exception->getMessage());
+                $failedActions++;
+            }
+        }
+
+        if ($failedActions > 0) {
+            throw new ActionFailed($failedActions . ' action(s) failed; please see above error messages');
+        }
     }
 
     /**

--- a/tests/CaptainHook/Config/FactoryTest.php
+++ b/tests/CaptainHook/Config/FactoryTest.php
@@ -104,6 +104,7 @@ class FactoryTest extends TestCase
         $this->assertEquals(false, $config->useAnsiColors());
         $this->assertEquals('docker', $config->getRunMode());
         $this->assertEquals('docker exec CONTAINER_NAME', $config->getRunExec());
+        $this->assertEquals(false, $config->failAtFirstError());
     }
 
     /**

--- a/tests/CaptainHook/ConfigTest.php
+++ b/tests/CaptainHook/ConfigTest.php
@@ -141,6 +141,24 @@ class ConfigTest extends TestCase
     }
 
     /**
+     * Tests Config::failAtFirstError default
+     */
+    public function testFailAtFirstErrorDefault(): void
+    {
+        $config = new Config('foo.json', true, []);
+        $this->assertEquals(true, $config->failAtFirstError());
+    }
+
+    /**
+     * Tests Config::failAtFirstError
+     */
+    public function testFailAtFirstError(): void
+    {
+        $config = new Config('foo.json', true, ['fail-at-first-error' => false]);
+        $this->assertEquals(false, $config->failAtFirstError());
+    }
+
+    /**
      * Tests Config::getJsonData
      */
     public function testGetJsonData(): void

--- a/tests/files/config/valid-with-all-settings.json
+++ b/tests/files/config/valid-with-all-settings.json
@@ -5,7 +5,8 @@
     "git-directory": "../../../.git",
     "run-mode": "docker",
     "run-exec": "docker exec CONTAINER_NAME",
-    "run-path": "/var/www/html"
+    "run-path": "/var/www/html",
+    "fail-at-first-error": false
   },
   "prepare-commit-msg": {
     "enabled": true,


### PR DESCRIPTION
This PR adds the `exec-all-actions` boolean setting. When enabled, all actions are executed (even if some of them fail). If any of these actions has failed, the hook finally finishes with a non-zero exit code.

Furthermore, I adjusted the console output to better connect action logging + action errors. For CLI commands, it is now clearer which output came from which command.