### PR TITLE
Add file is empty action

### DIFF
--- a/src/Hook/File/Action/IsEmpty.php
+++ b/src/Hook/File/Action/IsEmpty.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This file is part of CaptainHook
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CaptainHook\App\Hook\File\Action;
+
+use CaptainHook\App\Config;
+use CaptainHook\App\Config\Options;
+use CaptainHook\App\Console\IO;
+use CaptainHook\App\Exception\ActionFailed;
+use CaptainHook\App\Hook\Action;
+use Exception;
+use SebastianFeldmann\Git\Repository;
+
+/**
+ * Class IsEmpty
+ *
+ * @package CaptainHook
+ * @author  Felix Edelmann <fxedel@gmail.com>
+ * @link    https://github.com/captainhookphp/captainhook
+ * @since   TODO
+ */
+class IsEmpty implements Action
+{
+    /**
+     * Executes the action
+     *
+     * @param  \CaptainHook\App\Config           $config
+     * @param  \CaptainHook\App\Console\IO       $io
+     * @param  \SebastianFeldmann\Git\Repository $repository
+     * @param  \CaptainHook\App\Config\Action    $action
+     * @return void
+     * @throws \Exception
+     */
+    public function execute(Config $config, IO $io, Repository $repository, Config\Action $action): void
+    {
+        $options = $action->getOptions();
+        $files = $options->get('files');
+        if ($files === null) {
+            throw new Exception('Missing option "files" for IsEmpty action');
+        }
+
+        $failedFiles = 0;
+        foreach ($files as $file) {
+            if (!$this->isEmpty($file)) {
+                $io->write('- <error>FAIL</error> ' . $file, true);
+                $failedFiles++;
+            } else {
+                $io->write('- <info>OK</info> ' . $file, true, IO::VERBOSE);
+            }
+        }
+
+        if ($failedFiles > 0) {
+            throw new ActionFailed('<error>Error: ' . $failedFiles . ' non-empty file(s)</error>');
+        }
+
+        $io->write('<info>All files are empty or don\'t exist</info>');
+    }
+
+    /**
+     * Returns true when the file is empty or doesn't exist
+     *
+     * @param  string $file
+     * @return bool
+     */
+    protected function isEmpty($file): bool
+    {
+        if (!file_exists($file)) {
+            return true;
+        }
+
+        return filesize($file) === 0;
+    }
+}

--- a/src/Hook/File/Action/IsEmpty.php
+++ b/src/Hook/File/Action/IsEmpty.php
@@ -12,7 +12,6 @@
 namespace CaptainHook\App\Hook\File\Action;
 
 use CaptainHook\App\Config;
-use CaptainHook\App\Config\Options;
 use CaptainHook\App\Console\IO;
 use CaptainHook\App\Exception\ActionFailed;
 use CaptainHook\App\Hook\Action;

--- a/tests/CaptainHook/Hook/File/Action/IsEmptyTest.php
+++ b/tests/CaptainHook/Hook/File/Action/IsEmptyTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This file is part of CaptainHook
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CaptainHook\App\Hook\File\Action;
+
+use CaptainHook\App\Config;
+use CaptainHook\App\Console\IO\NullIO;
+use CaptainHook\App\Mockery;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class IsEmptyTest extends TestCase
+{
+    use Mockery;
+
+    /**
+     * Tests IsEmpty::execute
+     *
+     * @throws \Exception
+     */
+    public function testExecuteInvalidOption(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Missing option "files" for IsEmpty action');
+
+        $io     = new NullIO();
+        $config = new Config(CH_PATH_FILES . '/captainhook.json');
+        $repo    = $this->createRepositoryMock();
+        $action = new Config\Action(Regex::class);
+
+        $standard = new IsEmpty();
+        $standard->execute($config, $io, $repo, $action);
+    }
+
+    /**
+     * Tests RegexCheck::execute
+     *
+     * @throws \Exception
+     */
+    public function testExecuteSuccess(): void
+    {
+        $io     = new NullIO();
+        $config = new Config(CH_PATH_FILES . '/captainhook.json');
+        $action = new Config\Action(IsEmpty::class, ['files' => [
+            CH_PATH_FILES . '/doesNotExist.txt',
+            CH_PATH_FILES . '/storage/empty.log',
+        ]]);
+        $repo   = $this->createRepositoryMock();
+
+        $standard = new IsEmpty();
+        $standard->execute($config, $io, $repo, $action);
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Tests RegexCheck::execute
+     *
+     * @throws \Exception
+     */
+    public function testExecuteFailure(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('<error>Error: 1 non-empty file(s)</error>');
+
+        $io     = new NullIO();
+        $config = new Config(CH_PATH_FILES . '/captainhook.json');
+        $action = new Config\Action(IsEmpty::class, ['files' => [
+            CH_PATH_FILES . '/doesNotExist.txt', // pass
+            CH_PATH_FILES . '/storage/empty.log', // pass
+            CH_PATH_FILES . '/storage/test.json', // fail
+        ]]);
+        $repo   = $this->createRepositoryMock();
+
+        $standard = new IsEmpty();
+        $standard->execute($config, $io, $repo, $action);
+    }
+}


### PR DESCRIPTION
Adds an action that checks whether the configured (static) files are empty, e.g. an application's error log file.