### PR TITLE
Add file DoesNotContainRegex action

### DIFF
--- a/src/Hook/File/Action/DoesNotContainRegex.php
+++ b/src/Hook/File/Action/DoesNotContainRegex.php
@@ -27,7 +27,7 @@ use SebastianFeldmann\Git\Repository;
  * @link    https://github.com/captainhookphp/captainhook
  * @since   TODO
  */
-class NotContainsRegex implements Action
+class DoesNotContainRegex implements Action
 {
     /**
      * Executes the action
@@ -44,7 +44,7 @@ class NotContainsRegex implements Action
         $options = $action->getOptions();
         $regex = $options->get('regex');
         if ($regex === null) {
-            throw new Exception('Missing option "regex" for NotContainsRegex action');
+            throw new Exception('Missing option "regex" for DoesNotContainRegex action');
         }
 
         $files = $this->getFiles($options, $repository);

--- a/src/Hook/File/Action/NotContainsRegex.php
+++ b/src/Hook/File/Action/NotContainsRegex.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * This file is part of CaptainHook
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CaptainHook\App\Hook\File\Action;
+
+use CaptainHook\App\Config;
+use CaptainHook\App\Config\Options;
+use CaptainHook\App\Console\IO;
+use CaptainHook\App\Exception\ActionFailed;
+use CaptainHook\App\Hook\Action;
+use Exception;
+use SebastianFeldmann\Git\Repository;
+
+/**
+ * Class NotContainsRegex
+ *
+ * @package CaptainHook
+ * @author  Felix Edelmann <fxedel@gmail.com>
+ * @link    https://github.com/captainhookphp/captainhook
+ * @since   TODO
+ */
+class NotContainsRegex implements Action
+{
+    /**
+     * Executes the action
+     *
+     * @param  \CaptainHook\App\Config           $config
+     * @param  \CaptainHook\App\Console\IO       $io
+     * @param  \SebastianFeldmann\Git\Repository $repository
+     * @param  \CaptainHook\App\Config\Action    $action
+     * @return void
+     * @throws \Exception
+     */
+    public function execute(Config $config, IO $io, Repository $repository, Config\Action $action): void
+    {
+        $options = $action->getOptions();
+        $regex = $options->get('regex');
+        if ($regex === null) {
+            throw new Exception('Missing option "regex" for NotContainsRegex action');
+        }
+
+        $files = $this->getFiles($options, $repository);
+
+        $failedFiles = 0;
+        $totalMatchesCount = 0;
+        foreach ($files as $file) {
+            $fileContent = file_get_contents($file);
+            $matchCount = preg_match_all($regex, $fileContent, $matches);
+
+            if ($matchCount > 0) {
+                $io->write('- <error>FAIL</error> ' . $file . ' - ' . $matchCount . ' matches', true);
+                $failedFiles++;
+                $totalMatchesCount += $matchCount;
+            } else {
+                $io->write('- <info>OK</info> ' . $file, true, IO::VERBOSE);
+            }
+        }
+
+        if ($failedFiles > 0) {
+            $regexName = $options->get('regexName', $regex);
+            throw new ActionFailed('<error>Regex \'' . $regexName . '\' failed:</error> ' . $totalMatchesCount . ' matches in ' . $failedFiles . ' files');
+        }
+
+        $io->write('<info>No regex matches found</info>');
+    }
+
+    /**
+     * Returns the files that need to be checked.
+     * 
+     * @param  \CaptainHook\App\Config\Options   $options
+     * @param  \SebastianFeldmann\Git\Repository $repository
+     * @return array
+     */
+    protected function getFiles(Options $options, Repository $repository): array
+    {
+        $index = $repository->getIndexOperator();
+
+        $fileExtensions = $options->get('fileExtensions');
+        if ($fileExtensions !== null) {
+            $files = [];
+            foreach ($fileExtensions as $ext) {
+                $files = array_merge($files, $index->getStagedFilesOfType($ext));
+            }
+            return $files;
+        }
+
+        return $index->getStagedFiles();
+    }
+}

--- a/tests/CaptainHook/Hook/File/Action/DoesNotContainRegexTest.php
+++ b/tests/CaptainHook/Hook/File/Action/DoesNotContainRegexTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * This file is part of CaptainHook
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CaptainHook\App\Hook\File\Action;
+
+use CaptainHook\App\Config;
+use CaptainHook\App\Console\IO\NullIO;
+use CaptainHook\App\Mockery;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class DoesNotContainRegexTest extends TestCase
+{
+    use Mockery;
+
+    /**
+     * Tests DoesNotContainRegex::execute
+     *
+     * @throws \Exception
+     */
+    public function testExecuteInvalidOption(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Missing option "regex" for DoesNotContainRegex action');
+
+        $io     = new NullIO();
+        $config = new Config(CH_PATH_FILES . '/captainhook.json');
+        $repo    = $this->createRepositoryMock();
+        $action = new Config\Action(DoesNotContainRegex::class);
+
+        $standard = new DoesNotContainRegex();
+        $standard->execute($config, $io, $repo, $action);
+    }
+
+    /**
+     * Tests DoesNotContainRegex::execute
+     *
+     * @throws \Exception
+     */
+    public function testExecuteSuccess(): void
+    {
+        $io     = new NullIO();
+        $config = new Config(CH_PATH_FILES . '/captainhook.json');
+        $action = new Config\Action(DoesNotContainRegex::class, [
+            'regex' => '#some regex that does not match#'
+        ]);
+        $repo   = $this->createRepositoryMock();
+        $repo->method('getIndexOperator')->willReturn(
+            $this->createGitIndexOperator([
+                CH_PATH_FILES . '/storage/regextest1.txt'
+            ])
+        );
+
+        $standard = new DoesNotContainRegex();
+        $standard->execute($config, $io, $repo, $action);
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Tests DoesNotContainRegex::execute
+     *
+     * @throws \Exception
+     */
+    public function testExecuteFailure(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('<error>Regex \'#foo#\' failed:</error> 1 matches in 1 files');
+
+        $io     = new NullIO();
+        $config = new Config(CH_PATH_FILES . '/captainhook.json');
+        $action = new Config\Action(DoesNotContainRegex::class, [
+            'regex' => '#foo#'
+        ]);
+        $repo   = $this->createRepositoryMock();
+        $repo->method('getIndexOperator')->willReturn(
+            $this->createGitIndexOperator([
+                CH_PATH_FILES . '/storage/regextest1.txt',
+            ])
+        );
+
+        $standard = new DoesNotContainRegex();
+        $standard->execute($config, $io, $repo, $action);
+    }
+
+    /**
+     * Tests DoesNotContainRegex::execute
+     *
+     * @throws \Exception
+     */
+    public function testExecuteFailureWithCount(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('<error>Regex \'#foo#\' failed:</error> 3 matches in 2 files');
+
+        $io     = new NullIO();
+        $config = new Config(CH_PATH_FILES . '/captainhook.json');
+        $action = new Config\Action(DoesNotContainRegex::class, [
+            'regex' => '#foo#'
+        ]);
+        $repo   = $this->createRepositoryMock();
+        $repo->method('getIndexOperator')->willReturn(
+            $this->createGitIndexOperator([
+                CH_PATH_FILES . '/storage/regextest1.txt',
+                CH_PATH_FILES . '/storage/regextest2.txt',
+            ])
+        );
+
+        $standard = new DoesNotContainRegex();
+        $standard->execute($config, $io, $repo, $action);
+    }
+
+    /**
+     * Tests DoesNotContainRegex::execute
+     *
+     * @throws \Exception
+     */
+    public function testExecuteSuccessWithFileExtension(): void
+    {
+        $io     = new NullIO();
+        $config = new Config(CH_PATH_FILES . '/captainhook.json');
+        $action = new Config\Action(DoesNotContainRegex::class, [
+            'regex' => '#.#',
+            'fileExtensions' => ['php']
+        ]);
+        $index  = $this->createGitIndexOperator([
+            CH_PATH_FILES . '/storage/regextest1.txt'
+        ]);
+        $index->method('getStagedFilesOfType')->willReturnCallback(function ($ext) {
+            if ($ext === 'txt') {
+                return [
+                    CH_PATH_FILES . '/storage/regextest1.txt'
+                ];
+            }
+            return [];
+        });
+        $repo = $this->createRepositoryMock();
+        $repo->method('getIndexOperator')->willReturn($index);
+
+        $standard = new DoesNotContainRegex();
+        $standard->execute($config, $io, $repo, $action);
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Tests DoesNotContainRegex::execute
+     *
+     * @throws \Exception
+     */
+    public function testExecuteFailureWithFileExtension(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('<error>Regex \'#foo#\' failed:</error> 1 matches in 1 files');
+
+        $io     = new NullIO();
+        $config = new Config(CH_PATH_FILES . '/captainhook.json');
+        $action = new Config\Action(DoesNotContainRegex::class, [
+            'regex' => '#foo#',
+            'fileExtensions' => ['txt']
+        ]);
+        $index  = $this->createGitIndexOperator([
+            CH_PATH_FILES . '/storage/regextest1.txt'
+        ]);
+        $index->method('getStagedFilesOfType')->willReturnCallback(function ($ext) {
+            if ($ext === 'txt') {
+                return [
+                    CH_PATH_FILES . '/storage/regextest1.txt'
+                ];
+            }
+            return [];
+        });
+        $repo   = $this->createRepositoryMock();
+        $repo->method('getIndexOperator')->willReturn($index);
+
+        $standard = new DoesNotContainRegex();
+        $standard->execute($config, $io, $repo, $action);
+    }
+}

--- a/tests/files/storage/regextest1.txt
+++ b/tests/files/storage/regextest1.txt
@@ -1,0 +1,3 @@
+foo
+bar
+baz

--- a/tests/files/storage/regextest2.txt
+++ b/tests/files/storage/regextest2.txt
@@ -1,0 +1,4 @@
+some text
+foo
+bar
+foobar


### PR DESCRIPTION
Adds an action that checks whether all staged files (may be filtered by file type) don't match the configured regex, e.g. to avoid some unwanted PHP functions.