### PR TITLE
WIP: Add support for filtering staged files by directory

### DIFF
--- a/src/Hook/Condition/FileStaged/InDirectory.php
+++ b/src/Hook/Condition/FileStaged/InDirectory.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This file is part of CaptainHook
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CaptainHook\App\Hook\Condition\FileStaged;
+
+use CaptainHook\App\Console\IO;
+use CaptainHook\App\Hook\Condition;
+use CaptainHook\App\Hook\Constrained;
+use CaptainHook\App\Hook\Restriction;
+use CaptainHook\App\Hooks;
+use SebastianFeldmann\Git\Repository;
+
+/**
+ * Class InDirectory
+ *
+ * All FileStaged conditions are only applicable for `pre-commit` hooks.
+ *
+ * Example configuration:
+ *
+ * "action": "some-action"
+ * "conditions": [
+ *   {"exec": "\\CaptainHook\\App\\Hook\\Condition\\FileStaged\\InDirectory",
+ *    "args": [
+ *      "src/"
+ *    ]}
+ * ]
+ *
+ * @package CaptainHook
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/captainhookphp/captainhook
+ * @since   Class available since Release 5.0.0
+ */
+class InDirectory implements Condition, Constrained
+{
+    /**
+     * Directory path to check e.g. 'src/' or 'path/To/Custom/Directory/'
+     *
+     * @var string
+     */
+    private $directory;
+
+    /**
+     * InDirectory constructor
+     *
+     * @param string $directory
+     */
+    public function __construct(string $directory)
+    {
+        $this->directory = $directory;
+    }
+
+    /**
+     * Return the hook restriction information
+     *
+     * @return \CaptainHook\App\Hook\Restriction
+     */
+    public static function getRestriction(): Restriction
+    {
+        return Restriction::fromArray([Hooks::PRE_COMMIT]);
+    }
+
+    /**
+     * Evaluates the condition
+     *
+     * @param  \CaptainHook\App\Console\IO       $io
+     * @param  \SebastianFeldmann\Git\Repository $repository
+     * @return bool
+     */
+    public function isTrue(IO $io, Repository $repository): bool
+    {
+        $files = $repository->getIndexOperator()->getStagedFiles();
+
+        $filtered = [];
+        foreach ($files as $file) {
+            if (strpos($file, $this->directory, 0) === 0) {
+                $filtered[] = $file;
+            }
+        }
+
+        return count($files) > 0;
+    }
+}

--- a/src/Runner/Action/Cli/Command/Placeholder/StagedFiles.php
+++ b/src/Runner/Action/Cli/Command/Placeholder/StagedFiles.php
@@ -51,6 +51,27 @@ class StagedFiles implements Placeholder
                ? $this->repository->getIndexOperator()->getStagedFilesOfType($options['of-type'])
                : $this->repository->getIndexOperator()->getStagedFiles();
 
+        if (isset($options['in-dir'])) {
+            $files = $this->filterByDirectory($files, $options['in-dir']);
+        }
+
         return implode(($options['separated-by'] ?? ' '), $files);
+    }
+
+    /**
+     * @param array $files
+     * @param string $directory
+     * @return array
+     */
+    private function filterByDirectory(array $files, string $directory): array
+    {
+        $filtered = [];
+        foreach ($files as $file) {
+            if (strpos($file, $directory, 0) === 0) {
+                $filtered[] = $file;
+            }
+        }
+
+        return $filtered;
     }
 }


### PR DESCRIPTION
Preliminary work for the issue #114 just to exchange ideas an opinions.

This PR adds a support for filtering the staged files for the `pre-commit` hook based on their location in the file tree.

## Example use case:

A project has been split into new code (i.e. `src/`) and legacy code (i.e. `lib/functions/`). The project owner wants to have strict coding style rules for the new code, but does not want to enforce these rules for the legacy code.

So they would add two new entries in the `captainhook.json` file. The additional filter `in-dir:src/` for the staged files, and a condition that the action should be run only if there indeed are staged files from that directory.
```json
{
  "action": "php-cs-fixer {$STAGED_FILES|of-type:php|in-dir:src/}",
  "options": [],
  "conditions": [
    {
      "exec": "\\CaptainHook\\App\\Hook\\Condition\\FileStaged\\OfType",
      "args": [
        "php"
      ]
    },
    {
      "exec": "\\CaptainHook\\App\\Hook\\Condition\\FileStaged\\InDirectory",
      "args": [
        "src"
      ]
    }
  ]
}

```
Now a single commit would be able to contain changes both to new and legacy code, but the coding style rules would be enforced only for the new code.

## Stuff to think about

While testing this, I realized that apparently the conditions are joined with `OR` and not with `AND`. This would be a problem for this particular use case, because one of the conditions might pass even though there wouldn't be any files to check when both of the filters get used. And not giving an explicit file list as parameter to php-cs-fixer would cause it to fall back to lint every single file in the whole project.

I wonder if the OR-combining is there by design?

Another topic is that I wonder if the new `in-dir` filter is generic enough use case to hard-code it into captainhook. I guess an ideal solution would be to expose a public API for defining new classes implementing the `Placeholder` interface. This way it would be possible to define whatever crazy custom rules for each project separately.
