### PR TITLE
Add configurable Or and And conditions

### DIFF
--- a/src/Hook/Condition/LogicalAnd.php
+++ b/src/Hook/Condition/LogicalAnd.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of CaptainHook
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace CaptainHook\App\Hook\Condition;
+
+use CaptainHook\App\Console\IO;
+use CaptainHook\App\Hook\Condition;
+use SebastianFeldmann\Git\Repository;
+
+/**
+ * This class needs to be named like this as a simple "And" is not allowed as class name
+ */
+final class LogicalAnd implements Condition
+{
+    use LogicalTrait;
+
+    public function isTrue(IO $io, Repository $repository): bool
+    {
+        foreach ($this->conditions as $condition) {
+            if (false === $condition->isTrue($io, $repository)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/Hook/Condition/LogicalOr.php
+++ b/src/Hook/Condition/LogicalOr.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of CaptainHook
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace CaptainHook\App\Hook\Condition;
+
+use CaptainHook\App\Console\IO;
+use CaptainHook\App\Hook\Condition;
+use SebastianFeldmann\Git\Repository;
+
+/**
+ * This class needs to be named like this as a simple "Or" is not allowed as class name
+ */
+final class LogicalOr implements Condition
+{
+    use LogicalTrait;
+
+    public function isTrue(IO $io, Repository $repository): bool
+    {
+        foreach ($this->conditions as $condition) {
+            if (true === $condition->isTrue($io, $repository)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Hook/Condition/LogicalTrait.php
+++ b/src/Hook/Condition/LogicalTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of CaptainHook
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace CaptainHook\App\Hook\Condition;
+
+use CaptainHook\App\Console\IO;
+use CaptainHook\App\Hook\Condition;
+use SebastianFeldmann\Git\Repository;
+
+/**
+ * This class needs to be named like this as a simple "And" is not allowed as class name
+ */
+trait LogicalTrait
+{
+    /** @var Condition[] */
+    private $conditions = [];
+
+    private function __construct(Condition ...$conditions)
+    {
+        $this->conditions = $conditions;
+    }
+
+    public static function fromConditionsArray(array $conditions): Condition
+    {
+        $realConditions = [];
+        foreach ($conditions as $condition) {
+            if (! $condition instanceof Condition) {
+                continue;
+            }
+
+            $realConditions[] = $condition;
+        }
+
+        return new static(...$realConditions);
+    }
+}

--- a/src/Runner/Condition.php
+++ b/src/Runner/Condition.php
@@ -92,6 +92,34 @@ class Condition
      */
     private function createCondition(Config\Condition $config): ConditionInterface
     {
+        if ($config->getExec() === 'and') {
+            $conditions = [];
+            foreach ($config->getArgs() as $condition) {
+                $currentCondition = $this->createCondition(
+                    new Config\Condition($condition['exec'], $condition['args'])
+                );
+                if (! $this->isApplicable($currentCondition)) {
+                    $this->io->write('Condition skipped due to hook constraint', true, IO::VERBOSE);
+                    continue;
+                }
+                $conditions[] = $currentCondition;
+            }
+            return ConditionInterface\LogicalAnd::fromConditionsArray($conditions);
+        }
+        if ($config->getExec() === 'or') {
+            $conditions = [];
+            foreach ($config->getArgs() as $condition) {
+                $currentCondition = $this->createCondition(
+                    new Config\Condition($condition['exec'], $condition['args'])
+                );
+                if (! $this->isApplicable($currentCondition)) {
+                    $this->io->write('Condition skipped due to hook constraint', true, IO::VERBOSE);
+                    continue;
+                }
+                $conditions[] = $currentCondition;
+            }
+            return ConditionInterface\LogicalOr::fromConditionsArray($conditions);
+        }
         if (Util::getExecType($config->getExec()) === 'cli') {
             return new Cli(new Processor(), $config->getExec());
         }

--- a/tests/CaptainHook/Config/FactoryTest.php
+++ b/tests/CaptainHook/Config/FactoryTest.php
@@ -91,6 +91,19 @@ class FactoryTest extends TestCase
      *
      * @throws \Exception
      */
+    public function testCreateWithNestedAndConditions(): void
+    {
+        $config = Factory::create(realpath(__DIR__ . '/../../files/config/valid-with-nested-and-conditions.json'));
+
+        $this->assertTrue($config->getHookConfig('pre-commit')->isEnabled());
+        $this->assertCount(1, $config->getHookConfig('pre-commit')->getActions());
+    }
+
+    /**
+     * Tests Factory::create
+     *
+     * @throws \Exception
+     */
     public function testCreateWithAllSetting(): void
     {
         $path   = realpath(__DIR__ . '/../../files/config/valid-with-all-settings.json');

--- a/tests/CaptainHook/Hook/Condition/LogicalAndTest.php
+++ b/tests/CaptainHook/Hook/Condition/LogicalAndTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright Andreas Heigl <andreas@heigl.org>
+ *
+ * Licenses under the MIT-license. For details see the included file LICENSE.md
+ */
+
+namespace CaptainHook\App\Hook\Condition;
+
+use CaptainHook\App\Console\IO\DefaultIO;
+use CaptainHook\App\Console\IO\Mockery as IOMockery;
+use CaptainHook\App\Hook\Condition;
+use CaptainHook\App\Mockery as AppMockery;
+use PHPUnit\Framework\TestCase;
+
+class LogicalAndTest extends TestCase
+{
+    use IOMockery;
+    use AppMockery;
+
+    /**
+     * @covers \CaptainHook\App\Hook\Condition\LogicalAnd::isTrue
+     * @covers \CaptainHook\App\Hook\Condition\LogicalAnd::fromConditionsArray
+     * @covers \CaptainHook\App\Hook\Condition\LogicalAnd::__construct
+     */
+    public function testBooleanAndReturnsFalseWithOneSuccess(): void
+    {
+        $io           = $this->createIOMock();
+        $repository   = $this->createRepositoryMock();
+        $true         = $this->getMockBuilder(Condition::class)->getMock();
+        $false        = $this->getMockBuilder(Condition::class)->getMock();
+
+        $true->method('isTrue')->willReturn(true);
+        $false->method('isTrue')->willReturn(false);
+
+        $condition = LogicalAnd::fromConditionsArray([$true, $false]);
+
+        $this->assertFalse($condition->isTrue($io, $repository));
+    }
+
+    /**
+     * @covers \CaptainHook\App\Hook\Condition\LogicalAnd::isTrue
+     * @covers \CaptainHook\App\Hook\Condition\LogicalAnd::fromConditionsArray
+     * @covers \CaptainHook\App\Hook\Condition\LogicalAnd::__construct
+     */
+    public function testLogicalAndReturnsTrueWithAllSuccess(): void
+    {
+        $io           = $this->createIOMock();
+        $repository   = $this->createRepositoryMock();
+        $true         = $this->getMockBuilder(Condition::class)->getMock();
+
+        $true->method('isTrue')->willReturn(true);
+
+        $condition = LogicalAnd::fromConditionsArray([$true, $true, $true]);
+
+        $this->assertTrue($condition->isTrue($io, $repository));
+    }
+
+    /**
+     * @covers \CaptainHook\App\Hook\Condition\LogicalAnd::fromConditionsArray
+     */
+    public function testNamedConstructorIgnoresNonCondition(): void
+    {
+        $io           = $this->createIOMock();
+        $repository   = $this->createRepositoryMock();
+        $true         = $this->getMockBuilder(Condition::class)->getMock();
+        $true->expects($this->exactly(2))->method('isTrue')->willReturn(true);
+
+        $condition = LogicalAnd::fromConditionsArray([$true, 'string', $true]);
+
+        $this->assertTrue($condition->isTrue($io, $repository));
+    }
+}

--- a/tests/CaptainHook/Hook/Condition/LogicalOrTest.php
+++ b/tests/CaptainHook/Hook/Condition/LogicalOrTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Copyright Andreas Heigl <andreas@heigl.org>
+ *
+ * Licenses under the MIT-license. For details see the included file LICENSE.md
+ */
+
+namespace CaptainHook\App\Hook\Condition;
+
+use CaptainHook\App\Console\IO\Mockery as IOMockery;
+use CaptainHook\App\Hook\Condition;
+use CaptainHook\App\Mockery as AppMockery;
+use PHPUnit\Framework\TestCase;
+
+class LogicalOrTest extends TestCase
+{
+    use IOMockery;
+    use AppMockery;
+
+    /**
+     * @covers \CaptainHook\App\Hook\Condition\LogicalOr::isTrue
+     * @covers \CaptainHook\App\Hook\Condition\LogicalOr::fromConditionsArray
+     * @covers \CaptainHook\App\Hook\Condition\LogicalOr::__construct
+     */
+    public function testLogicalOrReturnsTrueWithOneSuccess(): void
+    {
+        $io           = $this->createIOMock();
+        $repository   = $this->createRepositoryMock();
+        $true         = $this->getMockBuilder(Condition::class)->getMock();
+        $false        = $this->getMockBuilder(Condition::class)->getMock();
+
+        $true->method('isTrue')->willReturn(true);
+        $false->method('isTrue')->willReturn(false);
+
+        $condition = LogicalOr::fromConditionsArray([$false, $true, $false]);
+
+        $this->assertTrue($condition->isTrue($io, $repository));
+    }
+
+    /**
+     * @covers \CaptainHook\App\Hook\Condition\LogicalOr::isTrue
+     * @covers \CaptainHook\App\Hook\Condition\LogicalOr::fromConditionsArray
+     * @covers \CaptainHook\App\Hook\Condition\LogicalOr::__construct
+     */
+    public function testLogicalOrReturnsFallsWithAllFailures(): void
+    {
+        $io           = $this->createIOMock();
+        $repository   = $this->createRepositoryMock();
+        $false         = $this->getMockBuilder(Condition::class)->getMock();
+
+        $false->method('isTrue')->willReturn(false);
+
+        $condition = LogicalOr::fromConditionsArray([$false, $false]);
+
+        $this->assertFalse($condition->isTrue($io, $repository));
+    }
+}

--- a/tests/CaptainHook/Runner/ConditionTest.php
+++ b/tests/CaptainHook/Runner/ConditionTest.php
@@ -96,4 +96,60 @@ class ConditionTest extends TestCase
         $runner = new Condition($io, $repository, 'pre-commit');
         $this->assertTrue($runner->doesConditionApply($conditionConfig));
     }
+
+    public function testAndConditionIsCorrectlyInterpreted(): void
+    {
+        $io = $this->createIOMock();
+        $io->expects($this->exactly(4))->method('getArgument')->willReturn('');
+
+        $operator   = $this->createGitDiffOperator(['fiz.php', 'baz.php', 'foo.php']);
+        $repository = $this->createRepositoryMock('');
+        $repository->expects($this->exactly(2))->method('getDiffOperator')->willReturn($operator);
+
+        $conditionConfig = new Config\Condition(
+            'and',
+            [[
+                'exec' => '\\' . Any::class,
+                'args' => [
+                    ['foo.php', 'bar.php']
+                ]
+            ], [
+                'exec' => '\\' . Any::class,
+                'args' => [
+                    ['foo.php', 'bar.php']
+                ]
+            ]]
+        );
+
+        $runner = new Condition($io, $repository, 'post-checkout');
+        $this->assertTrue($runner->doesConditionApply($conditionConfig));
+    }
+
+    public function testOrConditionIsCorrectlyInterpreted(): void
+    {
+        $io = $this->createIOMock();
+        $io->expects($this->exactly(4))->method('getArgument')->willReturn('');
+
+        $operator   = $this->createGitDiffOperator(['fiz.php', 'baz.php', 'foo.php']);
+        $repository = $this->createRepositoryMock('');
+        $repository->expects($this->exactly(2))->method('getDiffOperator')->willReturn($operator);
+
+        $conditionConfig = new Config\Condition(
+            'or',
+            [[
+                'exec' => '\\' . Any::class,
+                'args' => [
+                    ['buz.php', 'bar.php']
+                ]
+            ], [
+                'exec' => '\\' . Any::class,
+                'args' => [
+                    ['foo.php', 'bar.php']
+                ]
+            ]]
+        );
+
+        $runner = new Condition($io, $repository, 'post-checkout');
+        $this->assertTrue($runner->doesConditionApply($conditionConfig));
+    }
 }

--- a/tests/files/config/valid-with-nested-and-conditions.json
+++ b/tests/files/config/valid-with-nested-and-conditions.json
@@ -1,0 +1,39 @@
+{
+  "prepare-commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "commit-msg": {
+    "enabled": true,
+    "actions": []
+  },
+  "pre-commit": {
+    "enabled": true,
+    "actions": [
+      {
+        "action": "phpunit --configuration=build/phpunit-hook.xml",
+        "options": [],
+        "conditions": [
+          {
+            "exec": "and",
+            "args": [{
+              "exec": "\\CaptainHook\\App\\Hook\\Condition\\AnyFileChanged",
+              "args": [
+                ["foo.php", "bar.php"]
+              ]
+            },{
+              "exec": "\\CaptainHook\\App\\Hook\\Condition\\AnyFileChanged",
+              "args": [
+                ["foo.php", "bar.php"]
+              ]
+            }]
+          }
+        ]
+      }
+    ]
+  },
+  "pre-push": {
+    "enabled": false,
+    "actions": []
+  }
+}


### PR DESCRIPTION
This allows one to combine conditions for when to run git hooks using
boolean AND as well as boolean OR via the configuration.

The current conditional configuration is extended to use "and" or "or"
as value for the "exec" key and then an array of
condition-configurations as value for the "args" key.
So an example configuration would look like this:

```
"conditions": [{
    "exec": "and",
    "args": [{
        "exec": "\\CaptainHook\\App\\Hook\\Condition\\AnyFileChanged",
        "args": [
            ["foo.php", "bar.php"]
        ]
    },{
        "exec": "\\CaptainHook\\App\\Hook\\Condition\\AnyFileChanged",
        "args": [
            ["foo.php", "bar.php"]
        ]
    }]
}
```