### PR TITLE
Fixes #117 Feature/define php version

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -32,6 +32,7 @@ class Config
     public const SETTING_RUN_EXEC            = 'run-exec';
     public const SETTING_RUN_MODE            = 'run-mode';
     public const SETTING_RUN_PATH            = 'run-path';
+    public const SETTING_PHP_PATH            = 'php-path';
     public const SETTING_VERBOSITY           = 'verbosity';
     public const SETTING_FAIL_ON_FIRST_ERROR = 'fail-on-first-error';
 
@@ -180,6 +181,16 @@ class Config
     public function getRunPath(): string
     {
         return (string) ($this->settings[self::SETTING_RUN_PATH] ?? '');
+    }
+
+    /**
+     * Get configured php-path
+     *
+     * @return string
+     */
+    public function getPhpPath(): string
+    {
+        return (string) ($this->settings[self::SETTING_PHP_PATH] ?? '');
     }
 
     /**

--- a/src/Hook/Template/Builder.php
+++ b/src/Hook/Template/Builder.php
@@ -55,6 +55,8 @@ abstract class Builder
             throw new RuntimeException('bootstrap file not found: \'' . $bootstrapPath . '\'');
         }
 
+        $phpPath = $config->getPhpPath();
+
         switch ($config->getRunMode()) {
             case Template::DOCKER:
                 return new Docker(
@@ -69,7 +71,8 @@ abstract class Builder
                     new File($configPath),
                     new File($captainPath),
                     $config->getBootstrap(),
-                    $resolver->isPharRelease()
+                    $resolver->isPharRelease(),
+                    $phpPath
                 );
             default:
                 return new Shell(
@@ -77,7 +80,8 @@ abstract class Builder
                     new File($configPath),
                     new File($captainPath),
                     $config->getBootstrap(),
-                    $resolver->isPharRelease()
+                    $resolver->isPharRelease(),
+                    $phpPath
                 );
         }
     }

--- a/src/Hook/Template/Local.php
+++ b/src/Hook/Template/Local.php
@@ -49,6 +49,13 @@ abstract class Local implements Template
     protected $isPhar;
 
     /**
+     * Path to the php binary
+     *
+     * @var string
+     */
+    protected $phpPath;
+
+    /**
      * Local constructor
      *
      * @param \SebastianFeldmann\Camino\Path\Directory $repo
@@ -56,13 +63,21 @@ abstract class Local implements Template
      * @param \SebastianFeldmann\Camino\Path\File      $captainHook
      * @param string                                   $bootstrap
      * @param bool                                     $isPhar
+     * @param string                                   $phpPath
      */
-    public function __construct(Directory $repo, File $config, File $captainHook, string $bootstrap, bool $isPhar)
-    {
+    public function __construct(
+        Directory $repo,
+        File $config,
+        File $captainHook,
+        string $bootstrap,
+        bool $isPhar,
+        string $phpPath
+    ) {
         $this->bootstrap      = $bootstrap;
         $this->configPath     = $this->getPathForHookTo($repo, $config);
         $this->executablePath = $this->getPathForHookTo($repo, $captainHook);
         $this->isPhar         = $isPhar;
+        $this->phpPath        = $phpPath;
     }
 
     /**

--- a/src/Hook/Template/Local/Shell.php
+++ b/src/Hook/Template/Local/Shell.php
@@ -17,6 +17,7 @@ use CaptainHook\App\CH;
 use CaptainHook\App\Hook\Template;
 use SebastianFeldmann\Camino\Path;
 use SebastianFeldmann\Camino\Path\Directory;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 /**
  * Local class
@@ -77,6 +78,7 @@ class Shell extends Template\Local
             ];
         }
 
+        $executable = $this->phpPath === '' ? $this->executablePath : $this->phpPath . ' ' . $this->executablePath;
 
         return array_merge(
             [
@@ -89,7 +91,7 @@ class Shell extends Template\Local
             $useTTY,
             [
                 '',
-                $this->executablePath
+                $executable
                     . ' $INTERACTIVE'
                     . ' --configuration=' . $this->configPath
                     . ' --bootstrap=' . $this->bootstrap

--- a/tests/CaptainHook/Hook/Template/Local/PHPTest.php
+++ b/tests/CaptainHook/Hook/Template/Local/PHPTest.php
@@ -26,7 +26,9 @@ class PHPTest extends TestCase
         $config     = new File('/foo/bar/captainhook.json');
         $bootstrap  = new File('/foo/bar/vendor/autoload.php');
         $executable = new File('/foo/bar/vendor/bin/captainhook');
-        $template   = new PHP($repo, $config, $executable, $bootstrap, false);
+        $phpPath    = '';
+
+        $template   = new PHP($repo, $config, $executable, $bootstrap, false, $phpPath);
         $code       = $template->getCode('commit-msg');
 
         $this->assertStringContainsString('#!/usr/bin/env php', $code);
@@ -43,7 +45,9 @@ class PHPTest extends TestCase
         $config     = new File('/foo/bar/captainhook.json');
         $bootstrap  = new File('/foo/bar/vendor/autoload.php');
         $executable = new File('/usr/local/bin/captainhook');
-        $template   = new PHP($repo, $config, $executable, $bootstrap, false);
+        $phpPath    = '';
+
+        $template   = new PHP($repo, $config, $executable, $bootstrap, false, $phpPath);
         $code       = $template->getCode('commit-msg');
 
         $this->assertStringContainsString('#!/usr/bin/env php', $code);
@@ -60,7 +64,9 @@ class PHPTest extends TestCase
         $config     = new File('/foo/bar/captainhook.json');
         $bootstrap  = new File('/foo/bar/vendor/autoload.php');
         $executable = new File('/foo/bar/tools/captainhook.phar');
-        $template   = new PHP($repo, $config, $executable, $bootstrap, true);
+        $phpPath    = '';
+
+        $template   = new PHP($repo, $config, $executable, $bootstrap, true, $phpPath);
         $code       = $template->getCode('commit-msg');
 
         $this->assertStringContainsString('#!/usr/bin/env php', $code);

--- a/tests/CaptainHook/Hook/Template/Local/ShellTest.php
+++ b/tests/CaptainHook/Hook/Template/Local/ShellTest.php
@@ -26,8 +26,9 @@ class ShellTest extends TestCase
         $config     = new File('/foo/bar/captainhook.json');
         $executable = new File('/foo/bar/vendor/bin/captainhook');
         $bootstrap  = 'vendor/autoload.php';
+        $phpPath    = '';
 
-        $template = new Shell($repo, $config, $executable, $bootstrap, false);
+        $template = new Shell($repo, $config, $executable, $bootstrap, false, $phpPath);
         $code     = $template->getCode('commit-msg');
 
         $this->assertStringContainsString('#!/bin/sh', $code);
@@ -44,8 +45,9 @@ class ShellTest extends TestCase
         $config     = new File('/foo/bar/captainhook.json');
         $executable = new File('/usr/local/bin/captainhook');
         $bootstrap  = 'vendor/autoload.php';
+        $phpPath    = '';
 
-        $template = new Shell($repo, $config, $executable, $bootstrap, false);
+        $template = new Shell($repo, $config, $executable, $bootstrap, false, $phpPath);
         $code     = $template->getCode('commit-msg');
 
         $this->assertStringContainsString('#!/bin/sh', $code);
@@ -63,8 +65,9 @@ class ShellTest extends TestCase
         $config     = new File('/foo/bar/captainhook.json');
         $executable = new File('/usr/local/bin/captainhook');
         $bootstrap  = 'vendor/autoload.php';
+        $phpPath    = '';
 
-        $template = new Shell($repo, $config, $executable, $bootstrap, false);
+        $template = new Shell($repo, $config, $executable, $bootstrap, false, $phpPath);
         $code     = $template->getCode('prepare-commit-msg');
 
         $this->assertStringContainsString('#!/bin/sh', $code);

--- a/tests/CaptainHook/Hook/Template/Local/ShellTest.php
+++ b/tests/CaptainHook/Hook/Template/Local/ShellTest.php
@@ -33,6 +33,27 @@ class ShellTest extends TestCase
 
         $this->assertStringContainsString('#!/bin/sh', $code);
         $this->assertStringContainsString('commit-msg', $code);
+        $this->assertStringNotContainsString('php7.4', $code);
+        $this->assertStringContainsString('vendor/bin/captainhook $INTERACTIVE', $code);
+    }
+
+    /**
+     * Tests Shell::getCode
+     */
+    public function testTemplateWithDefinedPHP(): void
+    {
+        $repo       = new Directory('/foo/bar');
+        $config     = new File('/foo/bar/captainhook.json');
+        $executable = new File('/foo/bar/vendor/bin/captainhook');
+        $bootstrap  = 'vendor/autoload.php';
+        $phpPath    = '/usr/bin/php7.4';
+
+        $template = new Shell($repo, $config, $executable, $bootstrap, false, $phpPath);
+        $code     = $template->getCode('commit-msg');
+
+        $this->assertStringContainsString('#!/bin/sh', $code);
+        $this->assertStringContainsString('commit-msg', $code);
+        $this->assertStringContainsString('/usr/bin/php7.4', $code);
         $this->assertStringContainsString('vendor/bin/captainhook $INTERACTIVE', $code);
     }
 
@@ -52,6 +73,29 @@ class ShellTest extends TestCase
 
         $this->assertStringContainsString('#!/bin/sh', $code);
         $this->assertStringContainsString('commit-msg', $code);
+        $this->assertStringNotContainsString('php7.4', $code);
+        $this->assertStringContainsString('/usr/local/bin/captainhook $INTERACTIVE', $code);
+        $this->assertStringNotContainsString($this->getTtyRedirectionLines(), $code);
+    }
+
+    /**
+     * Tests Shell::getCode
+     */
+    public function testTemplateExtExecutableWithDefinedPHP(): void
+    {
+        $repo       = new Directory('/foo/bar');
+        $config     = new File('/foo/bar/captainhook.json');
+        $executable = new File('/usr/local/bin/captainhook');
+        $bootstrap  = 'vendor/autoload.php';
+        $phpPath    = '/usr/bin/php7.4';
+
+        $template = new Shell($repo, $config, $executable, $bootstrap, false, $phpPath);
+        $code     = $template->getCode('commit-msg');
+
+        $this->assertStringContainsString('#!/bin/sh', $code);
+        $this->assertStringContainsString('commit-msg', $code);
+
+        $this->assertStringContainsString('/usr/bin/php7.4', $code);
         $this->assertStringContainsString('/usr/local/bin/captainhook $INTERACTIVE', $code);
         $this->assertStringNotContainsString($this->getTtyRedirectionLines(), $code);
     }


### PR DESCRIPTION
Fixes #117 

With this, we are adding new `php-path` config option which is used (if provided) when writing git hook, so it looks something like this:
```
/usr/bin/php7.4 vendor/captainhook/captainhook/bin/captainhook $INTERACTIVE --configuration=captainhook.json --bootstrap=vendor/autoload.php hook:pre-commit "$@" <&0
``` 

Docs PR: https://github.com/captainhookphp/captainhook/pull/120