### PR TITLE
Fix grammar issues

### DIFF
--- a/src/Hook/Condition/FileChanged/All.php
+++ b/src/Hook/Condition/FileChanged/All.php
@@ -29,7 +29,7 @@ use SebastianFeldmann\Git\Repository;
 class All extends FileChanged
 {
     /**
-     * Check if all of the configured files where changed within the applied change set
+     * Check if all of the configured files were changed within the applied change set
      *
      * IMPORTANT: If no files are configured this condition is always true.
      *

--- a/src/Hook/File/Action/Exists.php
+++ b/src/Hook/File/Action/Exists.php
@@ -67,7 +67,7 @@ class Exists implements Action
         }
 
         if ($filesFailed > 0) {
-            throw new ActionFailed('<error>Error: ' . $filesFailed . ' file(s) where not found</error>');
+            throw new ActionFailed('<error>Error: ' . $filesFailed . ' file(s) were not found</error>');
         }
 
         $io->write('<info>All files exist</info>');

--- a/src/Hook/File/Action/MaxSize.php
+++ b/src/Hook/File/Action/MaxSize.php
@@ -81,7 +81,7 @@ class MaxSize implements Action, Constrained
         }
 
         if ($filesFailed > 0) {
-            $text = $filesFailed > 1 ? ' files where too big' : 'file is too big';
+            $text = $filesFailed > 1 ? ' files were too big' : 'file is too big';
             throw new ActionFailed('<error>Error: ' . $filesFailed . ' ' . $text . '</error>');
         }
 


### PR DESCRIPTION
Fix some grammar issues in docblocks and exception messages.

Are Exception messages considered as public API or are those safe to change?