### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/CaptainHook/Console/IO/ComposerIOTest.php
+++ b/tests/CaptainHook/Console/IO/ComposerIOTest.php
@@ -24,7 +24,7 @@ class ComposerIOTest extends TestCase
     /**
      * Test setup
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $mock = $this->getMockBuilder(IOInterface::class)
                      ->disableOriginalConstructor()
@@ -42,7 +42,7 @@ class ComposerIOTest extends TestCase
     /**
      * Test tear down
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->io = null;
     }


### PR DESCRIPTION
# Changed log

- According to the official [PHPUnit doc](https://phpunit.readthedocs.io/en/9.5/fixtures.html), it should be `protected function setUp(): void` and `protected function tearDown(): void`.