### PR TITLE
Fixed JSON Syntax

### DIFF
--- a/favorites.html
+++ b/favorites.html
@@ -61,6 +61,7 @@
         },
         "conditions": []
       }
+    ]
   }</code></pre>
 
   <h3 id="pre-commit">Soft quality checks on commit</h3>
@@ -83,6 +84,7 @@
           }
         ]
       }
+    ]
   }</code></pre>
 
   <h3 id="pre-push">Hard quality checks on push</h3>
@@ -100,6 +102,7 @@
         "options": [],
         "conditions": []
       }
+    ]
   }</code></pre>
 
   <h3 id="convenience">Convenience hooks</h3>
@@ -136,6 +139,7 @@
           }
         ]
       }
+    ]
   }</code></pre>
 
 </div>


### PR DESCRIPTION
Some examples had invalid JSON syntax. With this change the syntax is valid now.