### PR TITLE
add merging logic for includes from `captainhook.config.json`

### DIFF
--- a/src/Config/Factory.php
+++ b/src/Config/Factory.php
@@ -103,8 +103,11 @@ final class Factory
         Util::validateJsonConfiguration($json);
 
         $settings = $this->combineArgumentsAndSettingFile($file, $settings);
-        $settings = array_merge($this->extractSettings($json), $settings);
+        $settings = Util::mergeSettings($this->extractSettings($json), $settings);
         $config   = new Config($file->getPath(), true, $settings);
+        if (!empty($settings)) {
+            $json['config'] = $settings;
+        }
 
         $this->appendIncludedConfigurations($config, $json);
 

--- a/src/Config/Util.php
+++ b/src/Config/Util.php
@@ -142,6 +142,23 @@ abstract class Util
     }
 
     /**
+     * Merges a various list of settings arrays
+     *
+     * @param array ...$settings
+     * @return array
+     */
+    public static function mergeSettings(array ...$settings): array
+    {
+        $includes = array_column($settings, Config::SETTING_INCLUDES);
+        $mergedSettings = array_merge(...$settings);
+        if (!empty($includes)) {
+            $mergedSettings[Config::SETTING_INCLUDES] = array_merge(...$includes);
+        }
+
+        return $mergedSettings;
+    }
+
+    /**
      * Does an array have the expected keys
      *
      * @param  array $keys


### PR DESCRIPTION
This PR fixes the merging logic for includes from `captainhook.config.json`

fixes #144 