### PR TITLE
Allow use of Symfony v6 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,12 +39,12 @@
     "sebastianfeldmann/camino": "^0.9.2",
     "sebastianfeldmann/cli": "^3.3",
     "sebastianfeldmann/git": "^3.8.1",
-    "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0",
-    "symfony/filesystem": "^2.7 || ^3.0 || ^4.0 || ^5.0",
-    "symfony/process": "^2.7 || ^3.0 || ^4.0 || ^5.0"
+    "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
+    "symfony/filesystem": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
+    "symfony/process": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
   },
   "require-dev": {
-    "composer/composer": "~1",
+    "composer/composer": "~1 || ^2.0",
     "mikey179/vfsstream": "~1"
   },
   "bin": [


### PR DESCRIPTION
Changes `composer.json` to allow version `^6.0` of Symfony components. The tests all pass!