### PR TITLE
Support condition without required args in logic conditions

### DIFF
--- a/src/Runner/Condition.php
+++ b/src/Runner/Condition.php
@@ -118,7 +118,7 @@ class Condition
         $class      = '\\CaptainHook\\App\\Hook\\Condition\\Logic\\Logic' . ucfirst(strtolower($config->getExec()));
         $conditions = [];
         foreach ($config->getArgs() as $condition) {
-            $currentCondition = $this->createCondition(new Config\Condition($condition['exec'], $condition['args']));
+            $currentCondition = $this->createCondition(new Config\Condition($condition['exec'], $condition['args'] ?? []));
             if (!$this->isApplicable($currentCondition)) {
                 $this->io->write('Condition skipped due to hook constraint', true, IO::VERBOSE);
                 continue;


### PR DESCRIPTION
Currently it's not possible to use conditions that don't require args (have empty constructor) in logic conditions without explicitly defining `"args": []` in config file, which is superfluous.

PS. I have edited this file via Github web UI, hence "Unverified" commit.