### PR TITLE
Skip message validation for fixup commits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "ext-xml": "*",
     "sebastianfeldmann/camino": "^0.9.2",
     "sebastianfeldmann/cli": "^3.3",
-    "sebastianfeldmann/git": "^3.8.1",
+    "sebastianfeldmann/git": "^3.8.5",
     "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
     "symfony/filesystem": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
     "symfony/process": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0"

--- a/src/Runner/Hook.php
+++ b/src/Runner/Hook.php
@@ -140,15 +140,25 @@ abstract class Hook extends RepositoryAware
         $this->beforeHook();
 
         try {
-            $actions = $this->getActionsToExecute($hookConfigs);
-            // are any actions configured
-            if (count($actions) === 0) {
-                $this->io->write(' - no actions to execute', true);
-            } else {
-                $this->executeActions($actions);
-            }
+            $this->runHook($hookConfigs);
         } finally {
             $this->afterHook();
+        }
+    }
+
+    /**
+     * @param  \CaptainHook\App\Config\Hook[] $hookConfigs
+     * @return void
+     * @throws \Exception
+     */
+    protected function runHook(array $hookConfigs): void
+    {
+        $actions = $this->getActionsToExecute($hookConfigs);
+        // are any actions configured
+        if (count($actions) === 0) {
+            $this->io->write(' - no actions to execute');
+        } else {
+            $this->executeActions($actions);
         }
     }
 

--- a/src/Runner/Hook/CommitMsg.php
+++ b/src/Runner/Hook/CommitMsg.php
@@ -44,4 +44,21 @@ class CommitMsg extends Hook
 
         parent::beforeHook();
     }
+
+    /**
+     * Makes sure we do not run commit message validation for fixup commits
+     *
+     * @param  \CaptainHook\App\Config\Hook[] $hookConfigs
+     * @return void
+     * @throws \Exception
+     */
+    protected function runHook(array $hookConfigs): void
+    {
+        $msg = $this->repository->getCommitMsg();
+        if ($msg->isFixup()) {
+            $this->io->write(' - no commit message validation for fixup commits: skipping all actions');
+            return;
+        }
+        parent::runHook($hookConfigs);
+    }
 }

--- a/tests/unit/Runner/Hook/CommitMsgTest.php
+++ b/tests/unit/Runner/Hook/CommitMsgTest.php
@@ -16,6 +16,7 @@ use CaptainHook\App\Console\IO\Mockery as IOMockery;
 use CaptainHook\App\Mockery as CHMockery;
 use Exception;
 use PHPUnit\Framework\TestCase;
+use SebastianFeldmann\Git\CommitMessage as GitCommitMessage;
 use SebastianFeldmann\Git\Operator\Config as ConfigOperator;
 
 class CommitMsgTest extends TestCase
@@ -53,6 +54,38 @@ class CommitMsgTest extends TestCase
         $runner = new CommitMsg($io, $config, $repo);
         $runner->run();
     }
+
+    /**
+     * Tests CommitMsg::run
+     */
+    public function testRunHookSkippedBecauseOfFixup(): void
+    {
+        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            $this->markTestSkipped('not tested on windows');
+        }
+
+        $io       = $this->createIOMock();
+        $config   = $this->createConfigMock();
+        $configOp = $this->createMock(ConfigOperator::class);
+        $configOp->expects($this->once())->method('getSafely')->willReturn('#');
+
+        $repo = $this->createRepositoryMock();
+        $repo->expects($this->once())->method('getConfigOperator')->willReturn($configOp);
+        $repo->expects($this->once())->method('getCommitMsg')->willReturn(new GitCommitMessage('fixup! foo', '#'));
+
+        $hookConfig   = $this->createHookConfigMock();
+        $actionConfig = $this->createActionConfigMock();
+        $actionConfig->method('getAction')->willReturn(CH_PATH_FILES . '/bin/success');
+        $hookConfig->method('isEnabled')->willReturn(true);
+        $hookConfig->method('getActions')->willReturn([$actionConfig]);
+        $config->method('getHookConfig')->willReturn($hookConfig);
+        $io->expects($this->atLeast(1))->method('write');
+        $io->expects($this->once())->method('getArgument')->willReturn(CH_PATH_FILES . '/git/message/valid.txt');
+
+        $runner = new CommitMsg($io, $config, $repo);
+        $runner->run();
+    }
+
 
     /**
      * Tests CommitMsg::run


### PR DESCRIPTION
Because you can skip commit messages for fixup commits completely it does not make sense to validate them.