### PR TITLE
Use binary-only images for installing Composer

### DIFF
--- a/.docker/php7.3/Dockerfile
+++ b/.docker/php7.3/Dockerfile
@@ -12,7 +12,7 @@ RUN echo "error_reporting = E_ALL" >> /usr/local/etc/php/conf.d/docker-php-ext-x
     && echo "display_errors = On" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini;
 
-COPY --from=composer:2.0.0-RC2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer/composer:2-bin /composer /usr/bin/composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
 WORKDIR /docker

--- a/.docker/php7.4/Dockerfile
+++ b/.docker/php7.4/Dockerfile
@@ -12,7 +12,7 @@ RUN echo "error_reporting = E_ALL" >> /usr/local/etc/php/conf.d/docker-php-ext-x
     && echo "display_errors = On" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini;
 
-COPY --from=composer:2.0.0-RC2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer/composer:2-bin /composer /usr/bin/composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
 WORKDIR /docker

--- a/.docker/php8.1/Dockerfile
+++ b/.docker/php8.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-alpine
+FROM php:8.1-alpine
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 RUN install-php-extensions zip

--- a/.docker/php8.2/Dockerfile
+++ b/.docker/php8.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-alpine
+FROM php:8.2.0RC5-alpine
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 RUN install-php-extensions zip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,17 @@ services:
     volumes:
       - .:/docker:rw
     tty: true
+
+  php8.1:
+    build: .docker/php8.1
+    container_name: captainhook-php8.1
+    volumes:
+      - .:/docker:rw
+    tty: true
+
+  php8.2:
+    build: .docker/php8.2
+    container_name: captainhook-php8.2
+    volumes:
+      - .:/docker:rw
+    tty: true

--- a/phive.xml
+++ b/phive.xml
@@ -2,6 +2,6 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpunit" version="^9.4" installed="9.5.20" location="./tools/phpunit" copy="true"/>
   <phar name="humbug/box" version="^3.12.0" location="./tools/box" copy="true" installed="3.16.0"/>
-  <phar name="phpcs" version="^3.5" installed="3.6.2" location="./tools/phpcs" copy="true"/>
-  <phar name="phpstan" version="^1.0" installed="1.6.8" location="./tools/phpstan" copy="true"/>
+  <phar name="phpcs" version="^3.5" installed="3.7.1" location="./tools/phpcs" copy="true"/>
+  <phar name="phpstan" version="^1.0" installed="1.9.1" location="./tools/phpstan" copy="true"/>
 </phive>


### PR DESCRIPTION
See: https://blog.codito.dev/2022/11/composer-binary-only-docker-images/

Additionally I added support for missing PHP versions through Docker Compose 🙂 