### PR TITLE
improve typing

### DIFF
--- a/src/Config/Options.php
+++ b/src/Config/Options.php
@@ -41,9 +41,10 @@ class Options
     /**
      * Return a option value
      *
+     * @template T
      * @param  string $name
-     * @param  mixed  $default
-     * @return mixed
+     * @param  T      $default
+     * @return T
      */
     public function get(string $name, $default = null)
     {


### PR DESCRIPTION
we use `phpstan` and see this error `phpstan: Cannot cast mixed to int.`
```php
(int) $options->get('key', 100),
```

These changes will prevent the issue