### PR TITLE
allow ThatIs filter to take multivalued options (BC BREAK)

### DIFF
--- a/tests/unit/Hook/Condition/FileStaged/ThatIsTest.php
+++ b/tests/unit/Hook/Condition/FileStaged/ThatIsTest.php
@@ -46,6 +46,34 @@ class ThatIsTest extends TestCase
     /**
      * Tests ThatIs::isTrue
      */
+    public function testStagedTrueMultipleType(): void
+    {
+        $io    = $this->createIOMock();
+        $repo  = $this->createRepositoryMock();
+        $index = $this->createGitIndexOperator(['foo.php', 'bar.php']);
+        $repo->expects($this->once())->method('getIndexOperator')->willReturn($index);
+
+        $thatIs = new ThatIs(['ofType' => ['php', 'js']]);
+        $this->assertTrue($thatIs->isTrue($io, $repo));
+    }
+
+    /**
+     * Tests ThatIs::isTrue
+     */
+    public function testStagedFalseMultipleType(): void
+    {
+        $io    = $this->createIOMock();
+        $repo  = $this->createRepositoryMock();
+        $index = $this->createGitIndexOperator(['foo.php', 'bar.php']);
+        $repo->expects($this->once())->method('getIndexOperator')->willReturn($index);
+
+        $thatIs = new ThatIs(['ofType' => ['ts', 'js']]);
+        $this->assertFalse($thatIs->isTrue($io, $repo));
+    }
+
+    /**
+     * Tests ThatIs::isTrue
+     */
     public function testStagedTrueDirectory(): void
     {
         $io    = $this->createIOMock();
@@ -55,6 +83,48 @@ class ThatIsTest extends TestCase
 
         $thatIs = new ThatIs(['inDirectory' => 'bar/']);
         $this->assertTrue($thatIs->isTrue($io, $repo));
+    }
+
+    /**
+     * Tests ThatIs::isTrue
+     */
+    public function testStagedFalsePartialDirectory(): void
+    {
+        $io    = $this->createIOMock();
+        $repo  = $this->createRepositoryMock();
+        $index = $this->createGitIndexOperator(['foo/foo.php', 'foo/bar/bar.js', 'fiz/baz.txt']);
+        $repo->expects($this->once())->method('getIndexOperator')->willReturn($index);
+
+        $thatIs = new ThatIs(['inDirectory' => 'bar/']);
+        $this->assertFalse($thatIs->isTrue($io, $repo));
+    }
+
+    /**
+     * Tests ThatIs::isTrue
+     */
+    public function testStagedTrueMultipleDirectory(): void
+    {
+        $io = $this->createIOMock();
+        $repo = $this->createRepositoryMock();
+        $index = $this->createGitIndexOperator(['foo/foo.php', 'bar/bar.js', 'fiz/baz.txt']);
+        $repo->expects($this->once())->method('getIndexOperator')->willReturn($index);
+
+        $thatIs = new ThatIs(['inDirectory' => ['bar/', 'baz/']]);
+        $this->assertTrue($thatIs->isTrue($io, $repo));
+    }
+
+    /**
+     * Tests ThatIs::isTrue
+     */
+    public function testStagedFalseMultipleDirectory(): void
+    {
+        $io = $this->createIOMock();
+        $repo = $this->createRepositoryMock();
+        $index = $this->createGitIndexOperator(['foo/foo.php', 'bar/bar.js', 'fiz/baz.txt']);
+        $repo->expects($this->once())->method('getIndexOperator')->willReturn($index);
+
+        $thatIs = new ThatIs(['inDirectory' => ['foobar/', 'baz/']]);
+        $this->assertFalse($thatIs->isTrue($io, $repo));
     }
 
     /**


### PR DESCRIPTION
this fix allows to add a condition for *staged files contains a `php` file from either directory `foo` or `bar`* in the form

```json
"conditions": [
  {
    "exec": "\\CaptainHook\\App\\Hook\\Condition\\FileStaged\\ThatIs",
    "args": [
      {
        "ofType": "php",
        "inDirectory": ["foo/", "bar/"]
      }
    ]
  }
]
```

:warning: :warning: :warning: this also contains a *minor (IMHO)* BC break: :warning: :warning: :warning: 
- before, the inDirectory filter would return true if the directory is any part of the file path or name (for example, `"inDirectory": "foo/"` was true for `foo/bar.php` (OK), `bar/foo/bar.php` (KO)
- after, the directory must be the start of the path relative to git dir

@sebastianfeldmann do not hesitate to update or reject this PR if you disagree with it