### PR TITLE
Add interactive flag to docker exec

### DIFF
--- a/configure.html
+++ b/configure.html
@@ -393,7 +393,7 @@
     "includes": [],
     "plugins": [],
     "run-mode": "docker",
-    "run-exec": "docker exec CONTAINER_NAME",
+    "run-exec": "docker exec -i CONTAINER_NAME",
     "run-path": "vendor/bin/captainhook",
     "php-path": "/usr/bin/php7.4"
     "custom": {
@@ -501,7 +501,7 @@
   "ansi-colors": false,
   "fail-on-first-error": false,
   "run-mode": "docker",
-  "run-exec": "docker exec MY_CONTAINER_NAME",
+  "run-exec": "docker exec -i MY_CONTAINER_NAME",
   "run-path": "vendor/bin/captainhook",
   "custom": {
     "some-key": "some value"

--- a/install.html
+++ b/install.html
@@ -100,12 +100,12 @@
         If you don't have PHP installed locally or you have installed a different version, you can use Docker to
         execute CaptainHook. To do so you must install the hooks a bit differently.
       </p>
-      <pre><code class="bash">$ vendor/bin/captainhook install --run-mode=docker --run-exec="docker exec CONTAINER_NAME"</code></pre>
+      <pre><code class="bash">$ vendor/bin/captainhook install --run-mode=docker --run-exec="docker exec -i CONTAINER_NAME"</code></pre>
       <p>
         You can choose your preferred docker command e.g.:
       </p>
       <ul>
-        <li>docker exec MY_CONTAINER_NAME</li>
+        <li>docker exec -i MY_CONTAINER_NAME</li>
         <li>docker run --rm -v $(pwd):/var/www/html MY_IMAGE_NAME</li>
         <li>docker-compose -f docker/docker-compose.yml run --rm -T MY_SERVICE_NAME</li>
       </ul>
@@ -116,7 +116,7 @@
       <pre><code class="javascript">{
   "config": {
     "run-mode": "docker",
-    "run-exec": "docker exec CONTAINER_NAME"
+    "run-exec": "docker exec -i CONTAINER_NAME"
   }
   "pre-commit": {
     ...
@@ -127,7 +127,7 @@
         will not trigger the creation of a Docker container just to output that the hook is disabled. To make sure you
         only install enabled hooks use the corresponding flag during installation.
       </p>
-      <pre><code class="bash">$ vendor/bin/captainhook install --only-enabled --run-mode=docker --run-exec="docker exec CONTAINER_NAME"</code></pre>
+      <pre><code class="bash">$ vendor/bin/captainhook install --only-enabled --run-mode=docker --run-exec="docker exec -i CONTAINER_NAME"</code></pre>
 
       <h2>A word of warning</h2>
       <p class="pirate">


### PR DESCRIPTION
This is a follow-up of https://github.com/captainhookphp/captainhook/issues/211. Since some actions / conditions do not work when using `docker exec` without using the `-i` flag, I think the documentation should suggest using that flag. At least I do not see any disadvantage using the flag.

Reference: https://docs.docker.com/engine/reference/commandline/exec/#options