### PR TITLE
Allow diff filter setting for conditions

### DIFF
--- a/src/Hook/Condition/FileStaged.php
+++ b/src/Hook/Condition/FileStaged.php
@@ -31,16 +31,25 @@ abstract class FileStaged extends File
      *
      * @var array<string>
      */
-    protected $filesToWatch;
+    protected array $filesToWatch;
 
     /**
-     * FileChange constructor
+     * --diff-filter options
      *
-     * @param array<string> $files
+     * @var array<int, string>
      */
-    public function __construct(array $files)
+    protected array $diffFilter;
+
+    /**
+     * FileStaged constructor
+     *
+     * @param array<int, string> $files
+     * @param array<int, string> $diffFilter
+     */
+    public function __construct(array $files, array $diffFilter = [])
     {
         $this->filesToWatch = $files;
+        $this->diffFilter   = $diffFilter;
     }
 
     /**
@@ -70,6 +79,6 @@ abstract class FileStaged extends File
      */
     protected function getStagedFiles(Repository $repository)
     {
-        return $repository->getIndexOperator()->getStagedFiles();
+        return $repository->getIndexOperator()->getStagedFiles($this->diffFilter);
     }
 }

--- a/src/Hook/Condition/FileStaged/InDirectory.php
+++ b/src/Hook/Condition/FileStaged/InDirectory.php
@@ -45,16 +45,25 @@ class InDirectory implements Condition, Constrained
      *
      * @var string
      */
-    private $directory;
+    private string $directory;
+
+    /**
+     * --diff-filter options
+     *
+     * @var array<int, string>
+     */
+    private array $diffFilter;
 
     /**
      * InDirectory constructor
      *
-     * @param string $directory
+     * @param string             $directory
+     * @param array<int, string> $diffFilter
      */
-    public function __construct(string $directory)
+    public function __construct(string $directory, array $diffFilter = [])
     {
-        $this->directory = $directory;
+        $this->directory  = $directory;
+        $this->diffFilter = $diffFilter;
     }
 
     /**
@@ -76,7 +85,7 @@ class InDirectory implements Condition, Constrained
      */
     public function isTrue(IO $io, Repository $repository): bool
     {
-        $files = $repository->getIndexOperator()->getStagedFiles();
+        $files = $repository->getIndexOperator()->getStagedFiles($this->diffFilter);
 
         $filtered = [];
         foreach ($files as $file) {

--- a/src/Hook/Condition/FileStaged/OfType.php
+++ b/src/Hook/Condition/FileStaged/OfType.php
@@ -22,6 +22,7 @@ use SebastianFeldmann\Git\Repository;
  * Class OfType
  *
  * All FileStaged conditions are only applicable for `pre-commit` hooks.
+ * The diff filter argument is optional.
  *
  * Example configuration:
  *
@@ -29,7 +30,8 @@ use SebastianFeldmann\Git\Repository;
  * "conditions": [
  *   {"exec": "\\CaptainHook\\App\\Hook\\Condition\\FileStaged\\OfType",
  *    "args": [
- *      "php"
+ *      "php",
+ *      ["A", "C"]
  *    ]}
  * ]
  *
@@ -45,16 +47,25 @@ class OfType implements Condition, Constrained
      *
      * @var string
      */
-    private $suffix;
+    private string $suffix;
+
+    /**
+     * --diff-filter option
+     *
+     * @var array<int, string>
+     */
+    private array $diffFilter;
 
     /**
      * OfType constructor
      *
-     * @param string $type
+     * @param string             $type
+     * @param array<int, string> $filter
      */
-    public function __construct(string $type)
+    public function __construct(string $type, array $filter = [])
     {
-        $this->suffix = $type;
+        $this->suffix     = $type;
+        $this->diffFilter = $filter;
     }
 
     /**
@@ -76,7 +87,7 @@ class OfType implements Condition, Constrained
      */
     public function isTrue(IO $io, Repository $repository): bool
     {
-        $files = $repository->getIndexOperator()->getStagedFilesOfType($this->suffix);
+        $files = $repository->getIndexOperator()->getStagedFilesOfType($this->suffix, $this->diffFilter);
         return count($files) > 0;
     }
 }

--- a/src/Hook/Condition/FileStaged/ThatIs.php
+++ b/src/Hook/Condition/FileStaged/ThatIs.php
@@ -29,7 +29,7 @@ use SebastianFeldmann\Git\Repository;
  * "conditions": [
  *   {"exec": "\\CaptainHook\\App\\Hook\\Condition\\FileStaged\\ThatIs",
  *    "args": [
- *      {"ofType": "php", "inDirectory": "foo/"}
+ *      {"ofType": "php", "inDirectory": "foo/", "diff-filter": ["A", "C"]}
  *    ]}
  * ]
  *
@@ -55,14 +55,22 @@ class ThatIs implements Condition, Constrained
     private array $suffixes;
 
     /**
+     * --diff-filter options
+     *
+     * @var array<int, string>
+     */
+    private array $diffFilter;
+
+    /**
      * OfType constructor
      *
-     * @param array<string, string> $options
+     * @param array<string, mixed> $options
      */
     public function __construct(array $options)
     {
         $this->directories = (array)($options['inDirectory'] ?? []);
         $this->suffixes    = (array)($options['ofType'] ?? []);
+        $this->diffFilter  = (array)($options['diffFilter'] ?? []);
     }
 
     /**
@@ -84,7 +92,7 @@ class ThatIs implements Condition, Constrained
      */
     public function isTrue(IO $io, Repository $repository): bool
     {
-        $files = $repository->getIndexOperator()->getStagedFiles();
+        $files = $repository->getIndexOperator()->getStagedFiles($this->diffFilter);
         $files = $this->filterFilesByDirectory($files);
         $files = $this->filterFilesByType($files);
         return count($files) > 0;

--- a/tests/unit/Hook/Condition/FileStaged/AllTest.php
+++ b/tests/unit/Hook/Condition/FileStaged/AllTest.php
@@ -69,7 +69,7 @@ class AllTest extends TestCase
         $repository = $this->createRepositoryMock('');
         $repository->expects($this->once())->method('getIndexOperator')->willReturn($operator);
 
-        $fileStaged = new All(['foo.php', 'bar.php']);
+        $fileStaged = new All(['foo.php', 'bar.php'], ['A', 'C']);
 
         $this->assertTrue($fileStaged->isTrue($io, $repository));
     }

--- a/tests/unit/Hook/Condition/FileStaged/InDirectoryTest.php
+++ b/tests/unit/Hook/Condition/FileStaged/InDirectoryTest.php
@@ -53,7 +53,7 @@ class InDirectoryTest extends TestCase
         $index = $this->createGitIndexOperator(['src/foo.php', 'src/bar.php']);
         $repo->expects($this->once())->method('getIndexOperator')->willReturn($index);
 
-        $condition = new InDirectory('tests/');
+        $condition = new InDirectory('tests/', ['A', 'C']);
         $this->assertFalse($condition->isTrue($io, $repo));
     }
 }

--- a/tests/unit/Hook/Condition/FileStaged/OfTypeTest.php
+++ b/tests/unit/Hook/Condition/FileStaged/OfTypeTest.php
@@ -55,7 +55,7 @@ class OfTypeTest extends TestCase
         $index->expects($this->once())->method('getStagedFilesOfType')->willReturn([]);
         $repo->expects($this->once())->method('getIndexOperator')->willReturn($index);
 
-        $ofType = new OfType('js');
+        $ofType = new OfType('js', ['A', 'C']);
         $this->assertFalse($ofType->isTrue($io, $repo));
     }
 }

--- a/tests/unit/Hook/Condition/FileStaged/ThatIsTest.php
+++ b/tests/unit/Hook/Condition/FileStaged/ThatIsTest.php
@@ -123,7 +123,7 @@ class ThatIsTest extends TestCase
         $index = $this->createGitIndexOperator(['foo/foo.php', 'bar/bar.js', 'fiz/baz.txt']);
         $repo->expects($this->once())->method('getIndexOperator')->willReturn($index);
 
-        $thatIs = new ThatIs(['inDirectory' => ['foobar/', 'baz/']]);
+        $thatIs = new ThatIs(['inDirectory' => ['foobar/', 'baz/'], 'diffFilter' => ['A', 'C']]);
         $this->assertFalse($thatIs->isTrue($io, $repo));
     }
 


### PR DESCRIPTION
Since you can define diff filter for placeholders it is necessary to have the same functionality for conditions to not get into a situation where the condition applies and the placeholder is empty.

Issue: #220

This pull request adds the filter functionality to all `StagedFiles` conditions for `pre-commit` hooks.