### PR TITLE
Decrease action json footprint

### DIFF
--- a/src/Config/Action.php
+++ b/src/Config/Action.php
@@ -173,9 +173,13 @@ class Action
     public function getJsonData(): array
     {
         $data = [
-            'action'  => $this->action,
-            'options' => $this->options->getAll(),
+            'action'  => $this->action
         ];
+
+        $options = $this->options->getAll();
+        if (!empty($options)) {
+            $data['options'] = $options;
+        }
 
         $conditions = $this->getConditionJsonData();
         if (!empty($conditions)) {

--- a/tests/unit/Config/ActionTest.php
+++ b/tests/unit/Config/ActionTest.php
@@ -100,7 +100,7 @@ class ActionTest extends TestCase
         $action = new Action('\\Foo\\Bar');
         $config = $action->getJsonData();
 
-        $this->assertCount(0, $config['options']);
+        $this->assertCount(1, $config);
     }
 
     /**


### PR DESCRIPTION
In case no options exist don't create an empty option json.