### PR TITLE
Register uninstall console command into the Application

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -61,6 +61,7 @@ class Application extends SymfonyApplication
             parent::getDefaultCommands(),
             [
                 new Cmd\Install($resolver),
+                new Cmd\Uninstall($resolver),
                 new Cmd\Configuration($resolver),
                 new Cmd\Add($resolver),
                 new Cmd\Disable($resolver),


### PR DESCRIPTION
Hi!

I've just seen the new `Uninstall` console command but it's not registered to the `Application`. 

Thanks for your amazing work!