### PR TITLE
Fix commit issues on missing /dev/tty

### DIFF
--- a/src/Hook/Template/Docker.php
+++ b/src/Hook/Template/Docker.php
@@ -68,7 +68,9 @@ class Docker implements Template
         $path2Config = $this->pathInfo->getConfigPath();
         $config      = $path2Config !== CH::CONFIG ? ' --configuration=' . escapeshellarg($path2Config) : '';
         $bootstrap   = !empty($this->config->getBootstrap()) ? ' --bootstrap=' . $this->config->getBootstrap() : '';
-        $tty         = Hooks::allowsUserInput($hook) ? 'exec < /dev/tty' : '';
+        $tty         = Hooks::allowsUserInput($hook) 
+            ? "if sh -c \": >/dev/tty\" >/dev/null 2>/dev/null; then\n\texec < /dev/tty\nfi"
+            : '';
 
         $lines = [
             '#!/bin/sh',


### PR DESCRIPTION
This fixes an issue encountered during committing on WSL2 with PHPStorm. The message was: 
`.git/hooks/prepare-commit-msg: 2: cannot open /dev/tty: No such device or address`

Committing directly from WSL works but it looks like the execution step of PHPStorm breaks the behavior at that point.
The PR adds a check if /dev/tty exists before using it. 