### PR TITLE
Refactor array_merge out of loops

### DIFF
--- a/src/Git/ChangedFiles/Detector/PrePush.php
+++ b/src/Git/ChangedFiles/Detector/PrePush.php
@@ -103,13 +103,10 @@ class PrePush extends Detector
                 $newHash = 'HEAD';
             }
             if (!empty($oldHash)) {
-                $files = array_merge(
-                    $files,
-                    $this->repository->getDiffOperator()->getChangedFiles($oldHash, $newHash, $filter)
-                );
+                $files[] = $this->repository->getDiffOperator()->getChangedFiles($oldHash, $newHash, $filter);
             }
         }
-        return array_unique($files);
+        return array_unique(array_merge(...$files));
     }
 
     /**

--- a/src/Hook/File/Action/DoesNotContainRegex.php
+++ b/src/Hook/File/Action/DoesNotContainRegex.php
@@ -90,9 +90,9 @@ class DoesNotContainRegex extends Check
         $index = $repository->getIndexOperator();
         $files = [];
         foreach ($this->fileExtensions as $ext) {
-            $files = array_merge($files, $index->getStagedFilesOfType($ext));
+            $files[] = $index->getStagedFilesOfType($ext);
         }
-        return $files;
+        return array_merge(...$files);
     }
 
     /**

--- a/src/Runner/Config/Setup/Advanced.php
+++ b/src/Runner/Config/Setup/Advanced.php
@@ -107,11 +107,11 @@ class Advanced extends Guided implements Setup
         $options = [];
         $addOption = $this->io->ask('  <info>Add a validator option?</info> <comment>[y,n]</comment> ', 'n');
         while (IOUtil::answerToBool($addOption)) {
-            $options = array_merge($options, $this->getPHPActionOption());
+            $options[] = $this->getPHPActionOption();
             // add another action?
             $addOption = $this->io->ask('  <info>Add another validator option?</info> <comment>[y,n]</comment> ', 'n');
         }
-        return $options;
+        return array_merge(...$options);
     }
 
     /**


### PR DESCRIPTION
I have read the CONTRIBUTING.md, as this does not introduce a new feature and touches very few points in general, I did decide against opening an issue first. I hope that is ok.

`array_merge()` inside loops is quite slow. Take a look at the following PHPBench example:

```php
<?php

class ArrayMergeBench
{
  /**
   * @Revs(10000)
   * @Iterations(5)
   */
  public function benchMergeInLoop()
  {
    $result = [];

    for ($i=0; $i<100; $i++) {
      $result = array_merge($result, [$i]);
    }
  }

  /**
   * @Revs(10000)
   * @Iterations(5)
   */
  public function benchMergeOutsideLoop()
  {
    $result = [];

    for ($i=0; $i<100; $i++) {
      $result[] = [$i];
    }

    $finalResult = array_merge(...$result);
  }
}
```

returns
| benchmark            | subject                   | set | revs    | its | mem_peak | mode     | rstdev |
|----------------------|---------------------------|-----|---------|-----|----------|----------|--------|
| ArrayMergeBench      | benchMergeInLoop          |     | 10000   | 5   | 2.808mb  | 23.545μs | ±3.24% |
| ArrayMergeBench      | benchMergeOutsideLoop     |     | 10000   | 5   | 2.808mb  | 6.114μs  | ±4.93% |

So even with a single element in the array, merging outside the loop is already 4x faster. The more elements in the loop, the slower merging inside will be.