### PR TITLE
add new pattern option

### DIFF
--- a/src/Hook/Message/Action/InjectIssueKeyFromBranch.php
+++ b/src/Hook/Message/Action/InjectIssueKeyFromBranch.php
@@ -107,10 +107,11 @@ class InjectIssueKeyFromBranch implements Action, Constrained
         $target = $options->get('into', 'body');
         $mode   = $options->get('mode', 'append');
         $prefix = $options->get('prefix', ' ');
+        $pattern = $options->get('pattern', '');
 
         // overwrite either subject or body
         $newMsgData          = ['subject' => $msg->getSubject(), 'body' => $msg->getBody()];
-        $newMsgData[$target] = $this->injectIssueId($issueID, $newMsgData[$target], $mode, $prefix);
+        $newMsgData[$target] = $this->injectIssueId($issueID, $newMsgData[$target], $mode, $prefix, $pattern);
 
         $comments = '';
         foreach ($msg->getLines() as $line) {
@@ -132,10 +133,21 @@ class InjectIssueKeyFromBranch implements Action, Constrained
      * @param  string $msg
      * @param  string $mode
      * @param  string $prefix
+     * @param  string $pattern
      * @return string
      */
-    private function injectIssueId(string $issueID, string $msg, string $mode, string $prefix): string
+    private function injectIssueId(string $issueID, string $msg, string $mode, string $prefix, string $pattern): string
     {
+        if (!empty($pattern)) {
+            $issueID = preg_replace_callback(
+                '/\$(\d+)/',
+                function ($matches) use ($issueID) {
+                    return $matches[1] === '1' ? $issueID : '';
+                },
+                $pattern
+            );
+        }
+
         return ltrim($mode === 'prepend' ? $prefix . $issueID . ' ' . $msg : $msg . $prefix . $issueID);
     }
 }

--- a/tests/unit/Hook/Message/Action/InjectIssueKeyFromBranchTest.php
+++ b/tests/unit/Hook/Message/Action/InjectIssueKeyFromBranchTest.php
@@ -17,8 +17,8 @@ use CaptainHook\App\Console\IO\Mockery as IOMockery;
 use CaptainHook\App\Exception\ActionFailed;
 use CaptainHook\App\Mockery as CHMockery;
 use CaptainHook\App\RepoMock;
-use SebastianFeldmann\Git\CommitMessage;
 use PHPUnit\Framework\TestCase;
+use SebastianFeldmann\Git\CommitMessage;
 
 class InjectIssueKeyFromBranchTest extends TestCase
 {
@@ -44,7 +44,7 @@ class InjectIssueKeyFromBranchTest extends TestCase
     public function testPrependSubject(): void
     {
         $repo = new RepoMock();
-        $info = $this->createGitInfoOperator('5.0.0', 'freature/ABCD-12345-foo-bar-baz');
+        $info = $this->createGitInfoOperator('5.0.0', 'feature/ABCD-12345-foo-bar-baz');
 
         $repo->setCommitMsg(new CommitMessage('foo' . PHP_EOL . PHP_EOL . 'bar'));
         $repo->setInfoOperator($info);
@@ -71,7 +71,7 @@ class InjectIssueKeyFromBranchTest extends TestCase
     public function testAppendSubject(): void
     {
         $repo = new RepoMock();
-        $info = $this->createGitInfoOperator('5.0.0', 'freature/ABCD-12345-foo-bar-baz');
+        $info = $this->createGitInfoOperator('5.0.0', 'feature/ABCD-12345-foo-bar-baz');
 
         $repo->setCommitMsg(new CommitMessage('foo' . PHP_EOL . PHP_EOL . 'bar'));
         $repo->setInfoOperator($info);
@@ -98,7 +98,7 @@ class InjectIssueKeyFromBranchTest extends TestCase
     public function testAppendBodyWithPrefix(): void
     {
         $repo = new RepoMock();
-        $info = $this->createGitInfoOperator('5.0.0', 'freature/ABCD-12345-foo-bar-baz');
+        $info = $this->createGitInfoOperator('5.0.0', 'feature/ABCD-12345-foo-bar-baz');
 
         $repo->setCommitMsg(new CommitMessage('foo' . PHP_EOL . PHP_EOL . 'bar'));
         $repo->setInfoOperator($info);
@@ -130,7 +130,7 @@ class InjectIssueKeyFromBranchTest extends TestCase
     public function testAppendBodyWithPrefixWithComments(): void
     {
         $repo = new RepoMock();
-        $info = $this->createGitInfoOperator('5.0.0', 'freature/ABCD-12345-foo-bar-baz');
+        $info = $this->createGitInfoOperator('5.0.0', 'feature/ABCD-12345-foo-bar-baz');
 
         $repo->setCommitMsg(
             new CommitMessage(
@@ -221,7 +221,7 @@ class InjectIssueKeyFromBranchTest extends TestCase
     public function testIssueKeyAlreadyInMSG(): void
     {
         $repo = new RepoMock();
-        $info = $this->createGitInfoOperator('5.0.0', 'freature/ABCD-12345-foo-bar-baz');
+        $info = $this->createGitInfoOperator('5.0.0', 'feature/ABCD-12345-foo-bar-baz');
 
         $repo->setCommitMsg(new CommitMessage('ABCD-12345 foo' . PHP_EOL . PHP_EOL . 'bar'));
         $repo->setInfoOperator($info);
@@ -231,6 +231,62 @@ class InjectIssueKeyFromBranchTest extends TestCase
         $action  = $this->createActionConfigMock();
         $action->method('getOptions')->willReturn(new Options([
             'into' => 'subject',
+        ]));
+
+        $hook = new InjectIssueKeyFromBranch();
+        $hook->execute($config, $io, $repo, $action);
+
+        $this->assertEquals('ABCD-12345 foo', $repo->getCommitMsg()->getSubject());
+    }
+
+    /**
+     * Tests InjectIssueKeyFromBranch::execute
+     *
+     * @throws \Exception
+     */
+    public function testSubjectWithPattern(): void
+    {
+        $repo = new RepoMock();
+        $info = $this->createGitInfoOperator('5.0.0', 'feature/ABCD-12345-foo-bar-baz');
+
+        $repo->setCommitMsg(new CommitMessage('foo' . PHP_EOL . PHP_EOL . 'bar'));
+        $repo->setInfoOperator($info);
+
+        $io      = $this->createIOMock();
+        $config  = $this->createConfigMock();
+        $action  = $this->createActionConfigMock();
+        $action->method('getOptions')->willReturn(new Options([
+            'into' => 'subject',
+            'pattern' => '$1:',
+            'mode' => 'prepend',
+        ]));
+
+        $hook = new InjectIssueKeyFromBranch();
+        $hook->execute($config, $io, $repo, $action);
+
+        $this->assertEquals('ABCD-12345: foo', $repo->getCommitMsg()->getSubject());
+    }
+
+    /**
+     * Tests InjectIssueKeyFromBranch::execute
+     *
+     * @throws \Exception
+     */
+    public function testSubjectWithEmptyPattern(): void
+    {
+        $repo = new RepoMock();
+        $info = $this->createGitInfoOperator('5.0.0', 'feature/ABCD-12345-foo-bar-baz');
+
+        $repo->setCommitMsg(new CommitMessage('foo' . PHP_EOL . PHP_EOL . 'bar'));
+        $repo->setInfoOperator($info);
+
+        $io      = $this->createIOMock();
+        $config  = $this->createConfigMock();
+        $action  = $this->createActionConfigMock();
+        $action->method('getOptions')->willReturn(new Options([
+            'into' => 'subject',
+            'pattern' => '',
+            'mode' => 'prepend',
         ]));
 
         $hook = new InjectIssueKeyFromBranch();


### PR DESCRIPTION
This PR adds new option `pattern` which can be used in actions, e.g. prepare-commit-msg hook. It allows to not just prepend the subject of the commit msg with the ticket number, but also allows to add delimiters (here a colon) or other text.

**Example**:

Branch: `feature/ABC-123-my-refactoring-branch`
Commit-Message (before hook): "Some refactoring"
Commit-Message (after hook): "ABC-123: Some refactoring"

```
{
    "action": "\\CaptainHook\\App\\Hook\\Message\\Action\\InjectIssueKeyFromBranch",
    "options": {
          "regex": "(([A-Z]+-[0-9]+))",
          "pattern": "$1:",
          "into": "subject",
          "mode": "prepend",
          "force": false
    }
}
```



