### PR TITLE
Create release with PHP 8.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           coverage: none
           extensions: mbstring
-          php-version: 8.2
+          php-version: 8.0
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-dev --no-interaction --no-progress


### PR DESCRIPTION
Creating the release with PHP 8.2 means the phar will only work with PHP >= 8.2, because the composer platform_check.php script includes a check for PHP >= 8.2, running the phar on anything lower triggers the following fatal error:

```
Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 8.2.0". You are running 8.1.31. in phar:///Users/pierre/projects/...../vendor/bin/captainhook/vendor/composer/platform_check.php on line 24
```